### PR TITLE
[Feature #158761270] Add event update functionality.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = *migrations*
+exclude = *migrations*, *snap_*
 max-line-length = 100
 max-complexity = 15

--- a/server/a_socials/settings/dev.py
+++ b/server/a_socials/settings/dev.py
@@ -13,6 +13,8 @@ ALLOWED_HOSTS = ['*']
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+TEST_RUNNER = 'snapshottest.django.TestRunner'
+
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 DATABASES = {
@@ -34,5 +36,3 @@ DATABASES = {
 
 # SET WEBPACK_LOADER_CACHE
 WEBPACK_LOADER['DEFAULT']['CACHE'] = not DEBUG
-
-TEST_RUNNER = 'snapshottest.django.TestRunner'

--- a/server/graphql_schemas/event/schema.py
+++ b/server/graphql_schemas/event/schema.py
@@ -3,6 +3,7 @@ import graphene
 from graphene import relay, ObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
+from graphql_relay import from_global_id
 from graphql import GraphQLError
 
 from api.models import Event, Category, AndelaUserProfile
@@ -24,34 +25,72 @@ class CreateEvent(relay.ClientIDMutation):
         date = graphene.String(required=True)
         time = graphene.String(required=False)
         featured_image = graphene.String(required=False)
-        social_event_id = graphene.Int(required=False)
+        social_event_id = graphene.String(required=False)
+
     new_event = graphene.Field(EventNode)
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
         user = info.context.user
         social_event_id = input.get('social_event_id')
-        social_event = Category.objects.get(id=int(social_event_id))
-        andela_user_profile = AndelaUserProfile.objects.get(user_id=user.id)
+        social_event = Category.objects.get(
+            id=from_global_id(social_event_id)[1])
+        user = info.context.user
+        googleUser = GoogleUser.objects.first()
         new_event = Event(
-          title=input.get('title'),
-          description=input.get('description'),
-          venue=input.get('venue'),
-          date=input.get('date'),
-          time=input.get('time'),
-          featured_image=input.get('featured_image'),
-          creator=andela_user_profile,
-          social_event=social_event
+            title=input.get('title'),
+            description=input.get('description'),
+            venue=input.get('venue'),
+            date=input.get('date'),
+            time=input.get('time'),
+            featured_image=input.get('featured_image'),
+            creator=googleUser,
+            social_event=social_event
         )
         new_event.save()
 
         return cls(new_event=new_event)
 
 
+class UpdateEvent(relay.ClientIDMutation):
+
+    class Input:
+        title = graphene.String()
+        description = graphene.String()
+        venue = graphene.String()
+        date = graphene.String()
+        time = graphene.String()
+        featured_image = graphene.String()
+        social_event_id = graphene.Int()
+        event_id = graphene.String(required=True)
+
+    updated_event = graphene.Field(EventNode)
+
+    def update_instance(instance, args, exceptions=['event_id']):
+        if instance:
+            [setattr(instance, key, value)
+             for key, value in args.items() if key not in exceptions]
+        instance.save()
+        return instance
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **input):
+
+        try:
+            event_instance = Event.objects.get(
+                id=from_global_id(input.get('event_id'))[1]
+                )
+            if event_instance:
+                updated_event = cls.update_instance(
+                    event_instance, input)
+                return UpdateEvent(updated_event=updated_event)
+        except ValueError as e:
+            # return an error if something wrong happens
+            raise GraphQLError("{}".format(e))
+
+
 class EventQuery(object):
-    event = graphene.Field(EventNode,
-                           id=graphene.Int(),
-                           title=graphene.String())
+    event = relay.Node.Field(EventNode)
     events_list = DjangoFilterConnectionField(EventNode)
 
     def resolve_event(self, info, **kwargs):

--- a/server/graphql_schemas/event/schema.py
+++ b/server/graphql_schemas/event/schema.py
@@ -1,13 +1,13 @@
 import graphene
 
 from graphene import relay, ObjectType
+from graphql_relay.node.node import from_global_id
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
-from graphql_relay import from_global_id
 from graphql import GraphQLError
 
 from api.models import Event, Category, AndelaUserProfile
-from graphql_schemas.utils.helpers import is_not_admin
+from graphql_schemas.utils.helpers import is_not_admin, update_instance
 
 
 class EventNode(DjangoObjectType):
@@ -31,23 +31,27 @@ class CreateEvent(relay.ClientIDMutation):
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
-        user = info.context.user
         social_event_id = input.get('social_event_id')
-        social_event = Category.objects.get(
-            id=from_global_id(social_event_id)[1])
-        user = info.context.user
-        googleUser = GoogleUser.objects.first()
-        new_event = Event(
-            title=input.get('title'),
-            description=input.get('description'),
-            venue=input.get('venue'),
-            date=input.get('date'),
-            time=input.get('time'),
-            featured_image=input.get('featured_image'),
-            creator=googleUser,
-            social_event=social_event
-        )
-        new_event.save()
+        try:
+            social_event = Category.objects.get(
+                id=from_global_id(social_event_id)[1])
+            user_profile = AndelaUserProfile.objects.get(
+                user=info.context.user
+                )
+            new_event = Event(
+                title=input.get('title'),
+                description=input.get('description'),
+                venue=input.get('venue'),
+                date=input.get('date'),
+                time=input.get('time'),
+                featured_image=input.get('featured_image'),
+                creator=user_profile,
+                social_event=social_event
+            )
+            new_event.save()
+
+        except ValueError as e:
+            raise GraphQLError("An Error occurred. \n{}".format(e))
 
         return cls(new_event=new_event)
 
@@ -61,50 +65,41 @@ class UpdateEvent(relay.ClientIDMutation):
         date = graphene.String()
         time = graphene.String()
         featured_image = graphene.String()
-        social_event_id = graphene.Int()
+        social_event_id = graphene.String()
         event_id = graphene.String(required=True)
 
     updated_event = graphene.Field(EventNode)
-
-    def update_instance(instance, args, exceptions=['event_id']):
-        if instance:
-            [setattr(instance, key, value)
-             for key, value in args.items() if key not in exceptions]
-        instance.save()
-        return instance
+    action_message = graphene.String()
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
 
         try:
+            user = AndelaUserProfile.objects.get(user=info.context.user)
             event_instance = Event.objects.get(
-                id=from_global_id(input.get('event_id'))[1]
-                )
+                pk=from_global_id(input.get('event_id'))[1]
+            )
+            if event_instance.creator != user \
+                    and not info.context.user.is_superuser:
+                raise GraphQLError(
+                    "You are not authorized to edit this event.")
+            if input.get("social_event_id"):
+                input["social_event"] = Category.objects.get(
+                    pk=from_global_id(input.get('social_event_id'))[1]
+                    )
             if event_instance:
-                updated_event = cls.update_instance(
-                    event_instance, input)
-                return UpdateEvent(updated_event=updated_event)
+                updated_event = update_instance(
+                    event_instance,
+                    input,
+                    exceptions=["social_event_id", "event_id"]
+                )
+                return cls(
+                    action_message="Event Update is successful.",
+                    updated_event=updated_event
+                )
         except ValueError as e:
             # return an error if something wrong happens
-            raise GraphQLError("{}".format(e))
-
-
-class EventQuery(object):
-    event = relay.Node.Field(EventNode)
-    events_list = DjangoFilterConnectionField(EventNode)
-
-    def resolve_event(self, info, **kwargs):
-        id = kwargs.get('id')
-
-        if id is not None:
-            event = Event.objects.get(pk=id)
-            if not event.active:
-                return None
-            return event
-        return None
-
-    def resolve_events_list(self, info, **kwargs):
-        return Event.objects.exclude(active=False)
+            raise GraphQLError("An Error occurred. \n{}".format(e))
 
 
 class DeactivateEvent(relay.ClientIDMutation):
@@ -128,6 +123,25 @@ class DeactivateEvent(relay.ClientIDMutation):
         return cls(action_message="Event deactivated")
 
 
+class EventQuery(object):
+    event = relay.Node.Field(EventNode)
+    events_list = DjangoFilterConnectionField(EventNode)
+
+    def resolve_event(self, info, **kwargs):
+        id = kwargs.get('id')
+
+        if id is not None:
+            event = Event.objects.get(pk=id)
+            if not event.active:
+                return None
+            return event
+        return None
+
+    def resolve_events_list(self, info, **kwargs):
+        return Event.objects.exclude(active=False)
+
+
 class EventMutation(ObjectType):
     create_event = CreateEvent.Field()
     deactivate_event = DeactivateEvent.Field()
+    update_event = UpdateEvent.Field()

--- a/server/graphql_schemas/tests/events/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/events/snapshots/snap_test_mutations.py
@@ -42,3 +42,59 @@ snapshots['MutateEventTestCase::test_deactivate_event_as_non_creator 1'] = {
         }
     ]
 }
+
+snapshots['MutateEventTestCase::test_query_updated_event 1'] = {
+    'data': {
+        'event': {
+            'description': 'test description',
+            'id': 'RXZlbnROb2RlOjE=',
+            'title': 'test title'
+        }
+    }
+}
+
+snapshots['MutateEventTestCase::test_update_event_as_admin 1'] = {
+    'data': {
+        'updateEvent': {
+            'actionMessage': 'Event Update is successful.',
+            'updatedEvent': {
+                'id': 'RXZlbnROb2RlOjE=',
+                'time': '3PM',
+                'title': "This is a test don't panic."
+            }
+        }
+    }
+}
+
+snapshots['MutateEventTestCase::test_update_event_as_creator 1'] = {
+    'data': {
+        'updateEvent': {
+            'actionMessage': 'Event Update is successful.',
+            'updatedEvent': {
+                'id': 'RXZlbnROb2RlOjE=',
+                'time': '3PM',
+                'title': 'Not really a party'
+            }
+        }
+    }
+}
+
+snapshots['MutateEventTestCase::test_update_event_as_non_creator 1'] = {
+    'data': {
+        'updateEvent': None
+    },
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 13,
+                    'line': 3
+                }
+            ],
+            'message': 'You are not authorized to edit this event.',
+            'path': [
+                'updateEvent'
+            ]
+        }
+    ]
+}

--- a/server/graphql_schemas/tests/events/test_mutations.py
+++ b/server/graphql_schemas/tests/events/test_mutations.py
@@ -1,13 +1,13 @@
-from .base import BaseEventTestCase
 
 from contextlib import suppress
 from graphql import GraphQLError
 
+from .base import BaseEventTestCase, create_event
+
 
 class MutateEventTestCase(BaseEventTestCase):
     """
-    Test queries on events endpoint
-
+    Tests the events api queries and mutations
     """
     def test_deactivate_event_as_creator(self):
         query = """
@@ -48,3 +48,82 @@ class MutateEventTestCase(BaseEventTestCase):
         request.user = self.admin.user
         self.assertMatchSnapshot(client.execute(query,
                                  context_value=request))
+
+    def test_update_event_as_creator(self):
+        query = """
+            mutation UpdateEvent{
+            updateEvent(input:{
+                eventId:"RXZlbnROb2RlOjE=",
+                title:"Not really a party"
+            }){
+                updatedEvent{
+                id
+                title
+                time
+                }
+                actionMessage
+            }
+            }
+        """
+        request = self.request
+        client = self.client
+        request.user = self.event_creator.user
+        self.assertMatchSnapshot(client.execute(query, context_value=request))
+
+    def test_update_event_as_non_creator(self):
+        query = """
+            mutation UpdateEvent{
+            updateEvent(input:{
+                eventId:"RXZlbnROb2RlOjE=",
+                title:"it really is a party"
+            }){
+                updatedEvent{
+                id
+                title
+                time
+                }
+                actionMessage
+            }
+            }
+        """
+        request = self.request
+        client = self.client
+        request.user = self.non_event_creator.user
+        self.assertMatchSnapshot(client.execute(query, context_value=request))
+
+    def test_update_event_as_admin(self):
+        query = """
+            mutation UpdateEvent{
+                updateEvent(input:{
+                    eventId:"RXZlbnROb2RlOjE=",
+                    title:"This is a test don't panic."
+                }){
+                    updatedEvent{
+                    id
+                    title
+                    time
+                    }
+                    actionMessage
+                }
+            }
+        """
+        request = self.request
+        client = self.client
+        request.user = self.admin.user
+        self.assertMatchSnapshot(client.execute(query, context_value=request))
+
+    def test_query_updated_event(self):
+        query = """
+        query FetchUpdatedEvent{
+            event(id:"RXZlbnROb2RlOjE="){
+                id
+                title
+                description
+            }
+        }
+        """
+        request = self.request
+        client = self.client
+        create_event(self.admin, self.category, id=2)
+        request.user = self.event_creator.user
+        self.assertMatchSnapshot(client.execute(query, context_value=request))

--- a/server/graphql_schemas/utils/helpers.py
+++ b/server/graphql_schemas/utils/helpers.py
@@ -4,3 +4,20 @@ def is_not_admin(user):
         :param user
     """
     return not user.is_superuser
+
+
+def update_instance(instance, args, exceptions=['id']):
+    """
+        This function was created to help clean up input to be used for
+        updatingobjects. Typically the input from the graphql endpoint comes
+        with unwanted extras such as uniqueids that are not required or will
+        cause an error when updating an object hence the exceptionparameter.
+            :param instance:
+            :param args:
+            :param exceptions=['id']:
+    """
+    if instance:
+        [setattr(instance, key, value)
+            for key, value in args.items() if key not in exceptions]
+        instance.save()
+    return instance

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -51,3 +51,6 @@ urllib3==1.22
 virtualenv==16.0.0
 websocket-client==0.44.0
 whitenoise==3.3.0
+graphene-django==2.1rc1
+django-filter==1.0.4
+snapshottest==0.5.0


### PR DESCRIPTION
#### What Does This PR Do?
Add feature for updating/editing an event using GraphQL mutation.
#### Description Of Task To Be Completed
- Add mutation for `updateEvent`.
- Add tests for `updateEvent` mutation.

#### Any Background Context You Want To Provide?
- Updating events should be implemented as an `Update Event` feature to non-admin end users on the front end. This allows a creator to change the details of their events.

- I have chosen snapshot testing for [these reasons](http://docs.graphene-python.org/en/latest/testing/#snapshot-testing)

#### How can this be manually tested?
- run `python server/manage.py test server/graphql_schemas/tests`
- run the app, navigate to the `/graphql` endpoint and use the `updateEvent` mutation as shown in the gif below.

#### What are the related pivotal tracker stories
[#158761270](https://www.pivotaltracker.com/story/show/158761270)

#### Screenshot(s)
![update_event](https://user-images.githubusercontent.com/19896027/42810725-48c2728e-89c1-11e8-807b-6175b2d63150.gif)

