### PR TITLE
[FEATURE #159494668] Fix issues with the graphql endpoints

### DIFF
--- a/server/a_socials/settings/base.py
+++ b/server/a_socials/settings/base.py
@@ -207,7 +207,8 @@ REST_FRAMEWORK = {
 CORS_ORIGIN_ALLOW_ALL = True
 
 CORS_ALLOW_HEADERS = default_headers + (
-    'Authorization',
+  'Authorization',
+  'Token'
 )
 
 EMAIL_HOST = dotenv.get('EMAIL_HOST')

--- a/server/graphql_schemas/interest/schema.py
+++ b/server/graphql_schemas/interest/schema.py
@@ -18,9 +18,8 @@ class InterestNode(DjangoObjectType):
 
 class JoinSocialClub(relay.ClientIDMutation):
     """Join a social club"""
-
     class Input:
-        club_id = graphene.String(required=True)
+        club_id = graphene.ID(required=True)
 
     joined_social_club = graphene.Field(InterestNode)
 
@@ -42,7 +41,7 @@ class UnJoinSocialClub(relay.ClientIDMutation):
     """Unsubscribe from a social club"""
 
     class Input:
-        club_id = graphene.String(required=True)  # get the book id
+        club_id = graphene.ID(required=True)  # get the book id
 
     unjoined_social_club = graphene.Field(InterestNode)
 

--- a/server/graphql_schemas/tests/attend/test_mutations.py
+++ b/server/graphql_schemas/tests/attend/test_mutations.py
@@ -1,5 +1,6 @@
 import logging
 
+from graphql_relay import to_global_id
 from api.models import Attend, User
 from .base import BaseEventTestCase
 
@@ -12,26 +13,30 @@ class AttendanceTestCase(BaseEventTestCase):
     """
 
     def test_user_can_subcribe_to_event(self):
-        query = '''
-        mutation subscribe {
-            attendEvent(input: {eventId: 1, clientMutationId: "rand"}) {
+        query = f'''
+        mutation subscribe {{
+            attendEvent(input: {{
+                eventId: "{to_global_id("EventNode", self.event.id)}",
+                clientMutationId: "rand"
+            }})
+            {{
                 clientMutationId
-                newAttendance {
-                    event {
+                newAttendance {{
+                    event {{
                         title
                         description
                         venue
                         date
                         time
                         featuredImage
-                        socialEvent {
+                        socialEvent {{
                             name
                             description
-                        }
-                    }
-                }
-            }
-        }
+                        }}
+                    }}
+                }}
+            }}
+        }}
         '''
 
         self.request.user = self.user
@@ -43,26 +48,30 @@ class AttendanceTestCase(BaseEventTestCase):
             user=self.andela_user,
             event=self.event
         )
-        query = '''
-        mutation subscribe {
-            attendEvent(input: {eventId: 1, clientMutationId: "rand"}) {
+        query = f'''
+        mutation subscribe {{
+            attendEvent(input: {{
+                eventId: "{to_global_id("EventNode", self.event.id)}",
+                clientMutationId: "rand"
+            }})
+            {{
                 clientMutationId
-                newAttendance {
-                    event {
+                newAttendance {{
+                    event {{
                         title
                         description
                         venue
                         date
                         time
                         featuredImage
-                        socialEvent {
+                        socialEvent {{
                             name
                             description
-                        }
-                    }
-                }
-            }
-        }
+                        }}
+                    }}
+                }}
+            }}
+        }}
         '''
 
         self.request.user = self.user
@@ -70,26 +79,30 @@ class AttendanceTestCase(BaseEventTestCase):
         self.assertMatchSnapshot(result)
 
     def test_user_cannot_subscribe_to_nonexisting_event(self):
-        query = '''
-        mutation subscribe {
-            attendEvent(input: {eventId: 100, clientMutationId: "rand"}) {
+        query = f'''
+        mutation subscribe {{
+            attendEvent(input: {{
+                eventId: "{to_global_id("EventNode", 100)}",
+                clientMutationId: "rand"
+            }})
+            {{
                 clientMutationId
-                newAttendance {
-                    event {
+                newAttendance {{
+                    event {{
                         title
                         description
                         venue
                         date
                         time
                         featuredImage
-                        socialEvent {
+                        socialEvent {{
                             name
                             description
-                        }
-                    }
-                }
-            }
-        }
+                        }}
+                    }}
+                }}
+            }}
+        }}
         '''
 
         self.request.user = self.user
@@ -97,26 +110,30 @@ class AttendanceTestCase(BaseEventTestCase):
         self.assertMatchSnapshot(result)
 
     def test_nonexisting_user_cannot_subscribe_to_event(self):
-        query = '''
-        mutation subscribe {
-            attendEvent(input: {eventId: 1, clientMutationId: "rand"}) {
+        query = f'''
+        mutation subscribe {{
+            attendEvent(input: {{
+                eventId: "{to_global_id("EventNode", self.event.id)}",
+                clientMutationId: "rand"
+            }})
+            {{
                 clientMutationId
-                newAttendance {
-                    event {
+                newAttendance {{
+                    event {{
                         title
                         description
                         venue
                         date
                         time
                         featuredImage
-                        socialEvent {
+                        socialEvent {{
                             name
                             description
-                        }
-                    }
-                }
-            }
-        }
+                        }}
+                    }}
+                }}
+            }}
+        }}
         '''
 
         self.request.user = User(id=100)
@@ -124,26 +141,29 @@ class AttendanceTestCase(BaseEventTestCase):
         self.assertMatchSnapshot(result)
 
     def test_user_can_unsubscribe_from_event(self):
-        query = '''
-        mutation subscribe {
-            unattendEvent(input: {eventId: "2", clientMutationId: "rand"}) {
+        query = f'''
+        mutation subscribe {{
+            unattendEvent(input: {{
+                eventId: "{to_global_id("EventNode", self.event2.id)}",
+                clientMutationId: "rand"
+            }}) {{
                 clientMutationId
-                unsubscribedEvent {
-                    event {
+                unsubscribedEvent {{
+                    event {{
                         title
                         description
                         venue
                         date
                         time
                         featuredImage
-                        socialEvent {
+                        socialEvent {{
                             name
                             description
-                        }
-                    }
-                }
-            }
-        }
+                        }}
+                    }}
+                }}
+            }}
+        }}
         '''
 
         self.request.user = self.user
@@ -151,26 +171,30 @@ class AttendanceTestCase(BaseEventTestCase):
         self.assertMatchSnapshot(result)
 
     def test_user_cannot_unsubscribe_from_event_they_did_not_attend(self):
-        query = '''
-        mutation subscribe {
-            unattendEvent(input: {eventId: "1", clientMutationId: "rand"}) {
+        query = f'''
+        mutation subscribe {{
+            unattendEvent(input: {{
+                eventId: "{to_global_id("EventNode", self.event.id)}",
+                clientMutationId: "rand"
+            }})
+            {{
                 clientMutationId
-                unsubscribedEvent {
-                    event {
+                unsubscribedEvent {{
+                    event {{
                         title
                         description
                         venue
                         date
                         time
                         featuredImage
-                        socialEvent {
+                        socialEvent {{
                             name
                             description
-                        }
-                    }
-                }
-            }
-        }
+                        }}
+                    }}
+                }}
+            }}
+        }}
         '''
 
         self.request.user = self.user

--- a/server/graphql_schemas/tests/events/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/events/snapshots/snap_test_mutations.py
@@ -24,7 +24,7 @@ snapshots['MutateEventTestCase::test_create_event_with_calendar_unauthorizd 1'] 
     },
     'errors': [
         {
-            'AuthUrl': 'https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=1023621061664-1b7grp47bee4qu0k0a5114dvm1icl65k.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fv1%2Foauthcallback&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar&state=8WXg5fkRK8TDQKvtMhmh0jfqZhPBbm&prompt=consent&included_granted_scopes=true&login_hint=testemailcreatorId%40email.com&access_type=offline',
+            'AuthUrl': 'https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=1023621061664-1b7grp47bee4qu0k0a5114dvm1icl65k.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fv1%2Foauthcallback&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar&state=FRGZ9WvaihOHgFu5dkIqnKIHkZHrB8&prompt=consent&included_granted_scopes=true&login_hint=testemailcreatorId%40email.com&access_type=offline',
             'message': 'Calendar API not authorized'
         }
     ]
@@ -235,7 +235,7 @@ snapshots['MutateEventTestCase::test_validate_invite_link_invalid_hash 1'] = {
         'validateEventInvite': {
             'event': None,
             'isValid': False,
-            'message': 'Not Found: Invalid event/user in invite'
+            'message': 'Bad Request: Invalid invite URL'
         }
     }
 }

--- a/server/graphql_schemas/tests/events/test_mutations.py
+++ b/server/graphql_schemas/tests/events/test_mutations.py
@@ -14,12 +14,15 @@ class MutateEventTestCase(BaseEventTestCase):
     """
 
     def test_deactivate_event_as_creator(self):
-        query = """
-            mutation {
-                deactivateEvent(input: {eventId: 5}) {
+        query = f"""
+            mutation {{
+                deactivateEvent(input: {{
+                    eventId: "{to_global_id("EventNode", self.user_event.id)}"
+                }})
+                {{
                     actionMessage
-                }
-            } """
+                }}
+            }} """
         request = self.request
         client = self.client
         request.user = self.event_creator.user
@@ -28,12 +31,15 @@ class MutateEventTestCase(BaseEventTestCase):
 
     def test_deactivate_event_as_non_creator(self):
         with suppress(GraphQLError):
-            query = """
-            mutation {
-                deactivateEvent(input: {eventId: 5}) {
+            query = f"""
+            mutation {{
+                deactivateEvent(input: {{
+                    eventId: "{to_global_id("EventNode", self.user_event.id)}"
+                }})
+                {{
                     actionMessage
-                }
-            } """
+                }}
+            }} """
             request = self.request
             client = self.client
             request.user = self.non_event_creator.user
@@ -41,12 +47,15 @@ class MutateEventTestCase(BaseEventTestCase):
                                                     context_value=request))
 
     def test_deactivate_event_as_admin(self):
-        query = """
-        mutation {
-            deactivateEvent(input: {eventId: 5}) {
+        query = f"""
+        mutation {{
+            deactivateEvent(input: {{
+                eventId: "{to_global_id("EventNode", self.user_event.id)}"
+            }})
+            {{
                 actionMessage
-            }
-        } """
+            }}
+        }} """
         request = self.request
         client = self.client
         request.user = self.admin.user
@@ -375,7 +384,7 @@ class MutateEventTestCase(BaseEventTestCase):
         self.assertMatchSnapshot(result)
 
     def test_validate_invite_link_invalid_hash(self):
-        hash_string = Hasher.gen_hash([0,0,0])
+        hash_string = "amanhasnoname"
         query = f"""
             mutation ValidateInvite {{
                 validateEventInvite(input: {{


### PR DESCRIPTION
#### What Does This PR Do?
Restructures the graphql mutations to use the graphene auto generated ID, as opposed to using the id that is stored in the database, since the user interacts with the graphene ID from with in the queries

#### Description Of Task To Be Completed
 - Change the graphql mutations to use the graphene auto generated ID instead of the id that is stored in the database.
 - Fix the inconsistence of using `AndelaUserProfile` when interacting with the user object and when it is not used

#### Any Background Context You Want To Provide?
Some of graphql mutations are structured to use the database id in order to carry out data updates, yet the user interacts with the id that graphene generates.

#### How can this be manually tested?
- One should run the mutations in [Insomnia](https://insomnia.rest/)
- Run python server/manage.py test server/api/tests/

#### What are the relevant PT board issues?
[#159494668](https://www.pivotaltracker.com/story/show/159494668)

#### Screenshot(s)
None
