### PR TITLE
#159074167 Ensure uniformity in naming

### DIFF
--- a/server/api/models.py
+++ b/server/api/models.py
@@ -97,8 +97,8 @@ class AndelaUserProfile(models.Model):
                         idinfo: data passed in from post method.
                 """
         data = {
-          "user_picture": idinfo['picture'],
-          "slack_id": get_slack_id({"email": idinfo["email"]}),
+            "user_picture": idinfo['picture'],
+            "slack_id": get_slack_id({"email": idinfo["email"]}),
         }
 
         for field in data:
@@ -273,7 +273,6 @@ class UserEventHistory(models.Model):
                {self.event.title} {self.timestamp}'
 
     def save(self, *args, **kwargs):
-
         """This method is modified to check if user_event_action value is
         valid before user event history is created
 

--- a/server/graphql_schemas/attend/schema.py
+++ b/server/graphql_schemas/attend/schema.py
@@ -15,7 +15,7 @@ class AttendNode(DjangoObjectType):
         interfaces = (relay.Node,)
 
 
-class AttendSocialEvent(relay.ClientIDMutation):
+class AttendEvent(relay.ClientIDMutation):
     class Input:
         event_id = graphene.ID(required=True)
 
@@ -73,5 +73,5 @@ class AttendQuery(object):
 
 
 class AttendMutation(ObjectType):
-    attend_event = AttendSocialEvent.Field()
+    attend_event = AttendEvent.Field()
     unattend_event = UnsubscribeEvent.Field()

--- a/server/graphql_schemas/interest/schema.py
+++ b/server/graphql_schemas/interest/schema.py
@@ -16,57 +16,57 @@ class InterestNode(DjangoObjectType):
         interfaces = (relay.Node,)
 
 
-class JoinSocialClub(relay.ClientIDMutation):
-    """Join a social club"""
+class JoinCategory(relay.ClientIDMutation):
+    """Join a category"""
     class Input:
-        club_id = graphene.ID(required=True)
+        category_id = graphene.ID(required=True)
 
-    joined_social_club = graphene.Field(InterestNode)
+    joined_category = graphene.Field(InterestNode)
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
-        club_id = input.get('club_id')
+        category_id = input.get('category_id')
         user = AndelaUserProfile.objects.get(user=info.context.user)
-        user_category = Category.objects.get(pk=from_global_id(club_id)[1])
-        joined_social_club = Interest(
+        user_category = Category.objects.get(pk=from_global_id(category_id)[1])
+        joined_category = Interest(
             follower=user,
             follower_category=user_category
         )
-        joined_social_club.save()
+        joined_category.save()
 
-        return JoinSocialClub(joined_social_club=joined_social_club)
+        return JoinCategory(joined_category=joined_category)
 
 
-class UnJoinSocialClub(relay.ClientIDMutation):
-    """Unsubscribe from a social club"""
+class UnJoinCategory(relay.ClientIDMutation):
+    """Unsubscribe from a category"""
 
     class Input:
-        club_id = graphene.ID(required=True)  # get the book id
+        category_id = graphene.ID(required=True)
 
-    unjoined_social_club = graphene.Field(InterestNode)
+    unjoined_category = graphene.Field(InterestNode)
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
         category = Category.objects.get(
-            pk=from_global_id(input.get('club_id'))[1])
+            pk=from_global_id(input.get('category_id'))[1])
         user = AndelaUserProfile.objects.get(user=info.context.user)
-        unjoined_social_club = Interest.objects.filter(
+        unjoined_category = Interest.objects.filter(
             follower_category_id=category.id,
             follower_id=user.id
         ).first()
-        if not unjoined_social_club:
+        if not unjoined_category:
             raise GraphQLError(
                 "The User {0}, has not joined {1}. ".format(user, category))
 
-        unjoined_social_club.delete()
-        return UnJoinSocialClub(unjoined_social_club=unjoined_social_club)
+        unjoined_category.delete()
+        return UnJoinCategory(unjoined_category=unjoined_category)
 
 
 class InterestQuery(object):
     interest = relay.Node.Field(InterestNode)
     interests_list = DjangoFilterConnectionField(InterestNode)
 
-    joined_clubs = graphene.List(InterestNode)
+    joined_categories = graphene.List(InterestNode)
 
     def resolve_joined_clubs(self, info):
         user = info.context.user
@@ -74,5 +74,5 @@ class InterestQuery(object):
 
 
 class InterestMutation(graphene.ObjectType):
-    join_social_club = JoinSocialClub.Field()
-    un_join_social_club = UnJoinSocialClub.Field()
+    join_category = JoinCategory.Field()
+    unjoin_category = UnJoinCategory.Field()

--- a/server/graphql_schemas/tests/events/test_mutations.py
+++ b/server/graphql_schemas/tests/events/test_mutations.py
@@ -153,7 +153,7 @@ class MutateEventTestCase(BaseEventTestCase):
                 venue:"test venue",
                 time:"3PM",
                 date:"2018/12/01",
-                socialEventId: "Q2F0ZWdvcnlOb2RlOjI=",
+                categoryId: "Q2F0ZWdvcnlOb2RlOjI=",
                 featuredImage: "http://fake-image.com"
             }){
                 newEvent{
@@ -180,7 +180,7 @@ class MutateEventTestCase(BaseEventTestCase):
                 venue:"test venue",
                 time:"3PM",
                 date:"2018/12/01",
-                socialEventId: "Q2F0ZWdvcnlOb2RlOjE=",
+                categoryId: "Q2F0ZWdvcnlOb2RlOjE=",
                 featuredImage: "http://fake-image.com"
             }) {
                 newEvent{

--- a/server/graphql_schemas/tests/interest/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/interest/snapshots/snap_test_mutations.py
@@ -56,3 +56,46 @@ snapshots['InterestTestCase::test_user_cannot_unjoin_social_club_they_do_not_bel
         }
     ]
 }
+
+snapshots['InterestTestCase::test_user_can_join_and_unjoin_category 1'] = {
+    'data': {
+        'joinCategory': {
+            'joinedCategory': {
+                'followerCategory': {
+                    'description': 'For people who want to be happy.',
+                    'id': 'Q2F0ZWdvcnlOb2RlOjI=',
+                    'name': 'Python Meetup'
+                },
+                'id': 'SW50ZXJlc3ROb2RlOjQ='
+            }
+        }
+    }
+}
+
+snapshots['InterestTestCase::test_user_can_join_and_unjoin_category 2'] = {
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 13,
+                    'line': 3
+                }
+            ],
+            'message': 'Cannot query field "UnJoinCategory" on type "Mutation". Did you mean "unjoinCategory" or "joinCategory"?'
+        }
+    ]
+}
+
+snapshots['InterestTestCase::test_user_cannot_unjoin_category_they_do_not_belong_to 1'] = {
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 13,
+                    'line': 3
+                }
+            ],
+            'message': 'Cannot query field "unJoinCategory" on type "Mutation". Did you mean "unjoinCategory" or "joinCategory"?'
+        }
+    ]
+}

--- a/server/graphql_schemas/tests/interest/test_mutations.py
+++ b/server/graphql_schemas/tests/interest/test_mutations.py
@@ -6,14 +6,14 @@ class InterestTestCase(BaseEventTestCase):
     Test interest  queries
     """
 
-    def test_user_can_join_and_unjoin_social_club(self):
-        # Test for joining a social club
+    def test_user_can_join_and_unjoin_category(self):
+        # Test for joining a category
         query = '''
         mutation{
-            joinSocialClub(input:{
-                clubId:"Q2F0ZWdvcnlOb2RlOjI="
+            joinCategory(input:{
+                categoryId:"Q2F0ZWdvcnlOb2RlOjI="
             }){
-                joinedSocialClub{
+                joinedCategory{
                 id
                 followerCategory{
                     id
@@ -29,13 +29,13 @@ class InterestTestCase(BaseEventTestCase):
         result = self.client.execute(query, context_value=self.request)
         self.assertMatchSnapshot(result)
 
-        # Tests unjoining a social club
+        # Tests unjoining a category
         query = '''
         mutation{
-            unJoinSocialClub(input:{
-                clubId:"Q2F0ZWdvcnlOb2RlOjI="
+            UnJoinCategory(input:{
+                categoryId:"Q2F0ZWdvcnlOb2RlOjI="
             }){
-                unjoinedSocialClub{
+                unjoinedCategory{
                 id
                 followerCategory{
                     id
@@ -51,13 +51,13 @@ class InterestTestCase(BaseEventTestCase):
         result = self.client.execute(query, context_value=self.request)
         self.assertMatchSnapshot(result)
 
-    def test_user_cannot_unjoin_social_club_they_do_not_belong_to(self):
+    def test_user_cannot_unjoin_category_they_do_not_belong_to(self):
         query = '''
         mutation{
-            unJoinSocialClub(input:{
-                clubId:"Q2F0ZWdvcnlOb2RlOjI="
+            unJoinCategory(input:{
+                categoryId:"Q2F0ZWdvcnlOb2RlOjI="
             }){
-                unjoinedSocialClub{
+                unjoinedCategory{
                 id
                 followerCategory{
                     id


### PR DESCRIPTION
#### What Does This PR Do?
Ensures uniformity in naming for categories and events.

#### Description Of Task To Be Completed
- Deprecate usage of `social clubs` for `category`.
- Remove instances where `social event` was used to refer to category.
- Update relevant tests

#### Any Background Context You Want To Provide?
There was usage of social clubs and category concurrently yet they all refer to the same thing. 

#### What are the relevant pivotal tracker stories?
- #159074167
