### PR TITLE
[Bug #159788086]Fixing data returned by subscribed events query.

### DIFF
--- a/server/graphql_schemas/attend/schema.py
+++ b/server/graphql_schemas/attend/schema.py
@@ -68,8 +68,7 @@ class AttendQuery(object):
     subscribed_events = graphene.List(AttendNode)
 
     def resolve_subscribed_events(self, info, **kwargs):
-        user = info.context.user
-        return Attend.objects.filter(user_id=user.id).all()
+        return Attend.objects.filter(user__user=info.context.user)
 
 
 class AttendMutation(ObjectType):


### PR DESCRIPTION
#### What Does This PR Do?
-  Fix subscribed events query to return the data.

#### Description Of Task To Be Completed
- This fixes an issue raised that the subcribed_events GraphQL query was not  returning data.

#### Any Background Context You Want To Provide?
- The underlying issue was that the DB query made was filtering through the AndelaUserProfile using the info.context.user(BaseUser) id which eventually returned an empty attend object.
- The fix I used was to move one level into the many-to-many relationship and filter through the AndelaUseProfile using the info.context.user and use the result to filter through the Attend model. 

#### How can this be manually tested?
- Make a Query for subscribed events on the graphql endpoint.

### ScreenShot
<img width="1642" alt="screen shot 2018-08-15 at 11 25 31 am" src="https://user-images.githubusercontent.com/19896027/44138862-f7e8cfec-a07d-11e8-8a11-5cb42a1d0ae7.png">


#### What are the relevant pivotal tracker stories?
[#159788086](https://www.pivotaltracker.com/story/show/159788086)

