### PR TITLE
#159819111 Create category mutation

### DIFF
--- a/server/graphql_schemas/category/schema.py
+++ b/server/graphql_schemas/category/schema.py
@@ -1,3 +1,4 @@
+import graphene
 from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
@@ -18,3 +19,21 @@ class CategoryNode(DjangoObjectType):
 class CategoryQuery(object):
     category = relay.Node.Field(CategoryNode)
     category_list = DjangoFilterConnectionField(CategoryNode)
+
+
+class CreateCategory(relay.ClientIDMutation):
+    class Input:
+        name = graphene.String()
+        featured_image = graphene.String(required=True)
+        description = graphene.String(required=True)
+
+    new_category = graphene.Field(CategoryNode)
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **input):
+        new_category = Category.objects.create(**input)
+        return cls(new_category=new_category)
+
+
+class CategoryMutation(graphene.ObjectType):
+    create_category = CreateCategory.Field()

--- a/server/graphql_schemas/schema.py
+++ b/server/graphql_schemas/schema.py
@@ -3,7 +3,7 @@ import graphene
 from graphene_django.debug import DjangoDebug
 
 from .attend.schema import AttendQuery, AttendMutation
-from .category.schema import CategoryQuery
+from .category.schema import CategoryQuery, CategoryMutation
 from .event.schema import EventQuery, EventMutation
 from .interest.schema import InterestQuery, InterestMutation
 
@@ -22,6 +22,7 @@ class Mutation(
   EventMutation,
   InterestMutation,
   AttendMutation,
+  CategoryMutation,
   graphene.ObjectType
   ):
     debug = graphene.Field(DjangoDebug, name='__debug')

--- a/server/graphql_schemas/tests/category/base.py
+++ b/server/graphql_schemas/tests/category/base.py
@@ -6,11 +6,10 @@ from snapshottest.django import TestCase
 from graphql_schemas.schema import schema
 
 
-class BaseEventTestCase(TestCase):
+class BaseCategoryTestCase(TestCase):
     def setUp(self):
         for index in range(1,6):
-            Category.objects.create(
-                id=index,
+            self.category = Category.objects.create(
                 name="Swimming Meetup {}".format(index),
                 description="For people who want to be happy.",
                 featured_image="https://cdn.elegantthemes.com/"

--- a/server/graphql_schemas/tests/category/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/category/snapshots/snap_test_mutations.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['CategoryTestCase::test_user_can_create_a_new_category 1'] = {
+    'data': {
+        'createCategory': {
+            'clientMutationId': None,
+            'newCategory': {
+                'description': 'testCategory is still a test',
+                'featuredImage': 'https://github.com',
+                'name': 'someCategory'
+            }
+        }
+    }
+}
+

--- a/server/graphql_schemas/tests/category/snapshots/snap_test_queries.py
+++ b/server/graphql_schemas/tests/category/snapshots/snap_test_queries.py
@@ -15,7 +15,7 @@ snapshots['CategoryTestCase::test_can_fetch_all_categories 1'] = {
                     'node': {
                         'description': 'For people who want to be happy.',
                         'featuredImage': 'https://cdn.elegantthemes.com/',
-                        'id': 'Q2F0ZWdvcnlOb2RlOjE=',
+                        'id': 'Q2F0ZWdvcnlOb2RlOjc=',
                         'name': 'Swimming Meetup 1'
                     }
                 },
@@ -23,7 +23,7 @@ snapshots['CategoryTestCase::test_can_fetch_all_categories 1'] = {
                     'node': {
                         'description': 'For people who want to be happy.',
                         'featuredImage': 'https://cdn.elegantthemes.com/',
-                        'id': 'Q2F0ZWdvcnlOb2RlOjI=',
+                        'id': 'Q2F0ZWdvcnlOb2RlOjg=',
                         'name': 'Swimming Meetup 2'
                     }
                 },
@@ -31,7 +31,7 @@ snapshots['CategoryTestCase::test_can_fetch_all_categories 1'] = {
                     'node': {
                         'description': 'For people who want to be happy.',
                         'featuredImage': 'https://cdn.elegantthemes.com/',
-                        'id': 'Q2F0ZWdvcnlOb2RlOjM=',
+                        'id': 'Q2F0ZWdvcnlOb2RlOjk=',
                         'name': 'Swimming Meetup 3'
                     }
                 },
@@ -39,7 +39,7 @@ snapshots['CategoryTestCase::test_can_fetch_all_categories 1'] = {
                     'node': {
                         'description': 'For people who want to be happy.',
                         'featuredImage': 'https://cdn.elegantthemes.com/',
-                        'id': 'Q2F0ZWdvcnlOb2RlOjQ=',
+                        'id': 'Q2F0ZWdvcnlOb2RlOjEw',
                         'name': 'Swimming Meetup 4'
                     }
                 },
@@ -47,7 +47,7 @@ snapshots['CategoryTestCase::test_can_fetch_all_categories 1'] = {
                     'node': {
                         'description': 'For people who want to be happy.',
                         'featuredImage': 'https://cdn.elegantthemes.com/',
-                        'id': 'Q2F0ZWdvcnlOb2RlOjU=',
+                        'id': 'Q2F0ZWdvcnlOb2RlOjEx',
                         'name': 'Swimming Meetup 5'
                     }
                 }
@@ -61,8 +61,8 @@ snapshots['CategoryTestCase::test_can_fetch_single_category 1'] = {
         'category': {
             'description': 'For people who want to be happy.',
             'featuredImage': 'https://cdn.elegantthemes.com/',
-            'id': 'Q2F0ZWdvcnlOb2RlOjE=',
-            'name': 'Swimming Meetup 1'
+            'id': 'Q2F0ZWdvcnlOb2RlOjE2',
+            'name': 'Swimming Meetup 5'
         }
     }
 }

--- a/server/graphql_schemas/tests/category/test_mutations.py
+++ b/server/graphql_schemas/tests/category/test_mutations.py
@@ -1,0 +1,38 @@
+import logging
+from django.db import transaction
+
+from graphql_relay import to_global_id
+from api.models import Category
+from .base import BaseCategoryTestCase
+
+logging.disable(logging.ERROR)
+
+
+class CategoryTestCase(BaseCategoryTestCase):
+    """
+    Test attend mutation queries
+    """
+
+    def test_user_can_create_a_new_category(self):
+        query = '''
+        mutation subscribe {
+            createCategory(input: {
+                name: "someCategory",
+                description: "testCategory is still a test",
+                featuredImage: "https://github.com",
+            })
+            {
+                clientMutationId
+                newCategory {
+                  name
+                  description
+                  featuredImage
+                }
+            }
+        }
+        '''
+
+        self.request.user = self.user
+        result = self.client.execute(query, context_value=self.request)
+        self.assertMatchSnapshot(result)
+

--- a/server/graphql_schemas/tests/category/test_queries.py
+++ b/server/graphql_schemas/tests/category/test_queries.py
@@ -1,7 +1,8 @@
-from .base import BaseEventTestCase
+from .base import BaseCategoryTestCase
+from graphql_relay import to_global_id
 
 
-class CategoryTestCase(BaseEventTestCase):
+class CategoryTestCase(BaseCategoryTestCase):
     """
     Test category  queries
     """
@@ -27,15 +28,15 @@ class CategoryTestCase(BaseEventTestCase):
         self.assertMatchSnapshot(result)
 
     def test_can_fetch_single_category(self):
-        query = '''
-        query{
-            category(id:"Q2F0ZWdvcnlOb2RlOjE="){
+        query = f'''
+        query{{
+            category(id:"{to_global_id("CategoryNode", self.category.id)}"){{
                 id
                 name
                 description
                 featuredImage
-            }
-        }
+            }}
+        }}
         '''
 
         self.request.user = self.user

--- a/server/graphql_schemas/tests/interest/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/interest/snapshots/snap_test_mutations.py
@@ -73,20 +73,24 @@ snapshots['InterestTestCase::test_user_can_join_and_unjoin_category 1'] = {
 }
 
 snapshots['InterestTestCase::test_user_can_join_and_unjoin_category 2'] = {
-    'errors': [
-        {
-            'locations': [
-                {
-                    'column': 13,
-                    'line': 3
-                }
-            ],
-            'message': 'Cannot query field "UnJoinCategory" on type "Mutation". Did you mean "unjoinCategory" or "joinCategory"?'
+    'data': {
+        'unjoinCategory': {
+            'unjoinedCategory': {
+                'followerCategory': {
+                    'description': 'For people who want to be happy.',
+                    'id': 'Q2F0ZWdvcnlOb2RlOjI=',
+                    'name': 'Python Meetup'
+                },
+                'id': 'SW50ZXJlc3ROb2RlOk5vbmU='
+            }
         }
-    ]
+    }
 }
 
 snapshots['InterestTestCase::test_user_cannot_unjoin_category_they_do_not_belong_to 1'] = {
+    'data': {
+        'unjoinCategory': None
+    },
     'errors': [
         {
             'locations': [
@@ -95,7 +99,10 @@ snapshots['InterestTestCase::test_user_cannot_unjoin_category_they_do_not_belong
                     'line': 3
                 }
             ],
-            'message': 'Cannot query field "unJoinCategory" on type "Mutation". Did you mean "unjoinCategory" or "joinCategory"?'
+            'message': 'The User @testuser2, has not joined Category : Python Meetup. ',
+            'path': [
+                'unjoinCategory'
+            ]
         }
     ]
 }

--- a/server/graphql_schemas/tests/interest/test_mutations.py
+++ b/server/graphql_schemas/tests/interest/test_mutations.py
@@ -32,7 +32,7 @@ class InterestTestCase(BaseEventTestCase):
         # Tests unjoining a category
         query = '''
         mutation{
-            UnJoinCategory(input:{
+            unjoinCategory(input:{
                 categoryId:"Q2F0ZWdvcnlOb2RlOjI="
             }){
                 unjoinedCategory{
@@ -54,7 +54,7 @@ class InterestTestCase(BaseEventTestCase):
     def test_user_cannot_unjoin_category_they_do_not_belong_to(self):
         query = '''
         mutation{
-            unJoinCategory(input:{
+            unjoinCategory(input:{
                 categoryId:"Q2F0ZWdvcnlOb2RlOjI="
             }){
                 unjoinedCategory{


### PR DESCRIPTION
#### What Does This PR Do?
- Allows users to create categories from the graphQL endpoint

#### Description Of Task To Be Completed
- When a user posts valid data to  the graphQl category endpoint, then a new category should be created.

#### Any Background Context You Want To Provide?
 - N/A

#### How can this be manually tested?
N/A
#### What are the relevant pivotal tracker stories?
#159819111

#### Screenshot(s)
