### PR TITLE
#159750242 Make invite links expire after event end time

### DIFF
--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2545,7 +2545,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.27.2:
+date-fns@^1.27.2, date-fns@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
@@ -7172,7 +7172,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -7328,6 +7328,12 @@ react-dom@16.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-fontawesome@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/react-fontawesome/-/react-fontawesome-1.6.1.tgz#eddce17e7dc731aa09fd4a186688a61793a16c5c"
+  dependencies:
+    prop-types "^15.5.6"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"

--- a/server/graphql_schemas/tests/attend/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/attend/snapshots/snap_test_mutations.py
@@ -33,7 +33,7 @@ snapshots['AttendanceTestCase::test_user_can_attend_an_event 1'] = {
             'clientMutationId': 'rand',
             'newAttendance': {
                 'event': {
-                    'id': 'RXZlbnROb2RlOjM=',
+                    'id': 'RXZlbnROb2RlOjk=',
                     'title': 'Test'
                 },
                 'status': 'ATTENDING'
@@ -48,7 +48,7 @@ snapshots['AttendanceTestCase::test_user_can_change_event_status 1'] = {
             'clientMutationId': 'rand',
             'newAttendance': {
                 'event': {
-                    'id': 'RXZlbnROb2RlOjU=',
+                    'id': 'RXZlbnROb2RlOjEx',
                     'title': 'Test'
                 },
                 'status': 'DECLINED'

--- a/server/graphql_schemas/tests/attend/snapshots/snap_test_queries.py
+++ b/server/graphql_schemas/tests/attend/snapshots/snap_test_queries.py
@@ -11,7 +11,7 @@ snapshots['AttendanceTestCase::test_can_fetch_single_attendance 1'] = {
     'data': {
         'eventAttendance': {
             'event': {
-                'id': 'RXZlbnROb2RlOjEw',
+                'id': 'RXZlbnROb2RlOjE2',
                 'title': 'Test Event 2'
             },
             'id': 'QXR0ZW5kTm9kZTo3',
@@ -25,7 +25,7 @@ snapshots['AttendanceTestCase::test_can_fetch_user_events 1'] = {
         'subscribedEvents': [
             {
                 'event': {
-                    'id': 'RXZlbnROb2RlOjEy',
+                    'id': 'RXZlbnROb2RlOjE4',
                     'title': 'Test Event 2'
                 },
                 'id': 'QXR0ZW5kTm9kZTo4',
@@ -42,7 +42,7 @@ snapshots['AttendanceTestCase::test_user_attend_model_is_populated_with_new_even
                 {
                     'node': {
                         'event': {
-                            'id': 'RXZlbnROb2RlOjE1',
+                            'id': 'RXZlbnROb2RlOjIx',
                             'title': 'test title'
                         },
                         'id': 'QXR0ZW5kTm9kZToxMg==',
@@ -52,7 +52,7 @@ snapshots['AttendanceTestCase::test_user_attend_model_is_populated_with_new_even
                 {
                     'node': {
                         'event': {
-                            'id': 'RXZlbnROb2RlOjE1',
+                            'id': 'RXZlbnROb2RlOjIx',
                             'title': 'test title'
                         },
                         'id': 'QXR0ZW5kTm9kZToxMQ==',
@@ -62,7 +62,7 @@ snapshots['AttendanceTestCase::test_user_attend_model_is_populated_with_new_even
                 {
                     'node': {
                         'event': {
-                            'id': 'RXZlbnROb2RlOjE1',
+                            'id': 'RXZlbnROb2RlOjIx',
                             'title': 'test title'
                         },
                         'id': 'QXR0ZW5kTm9kZToxMA==',
@@ -72,7 +72,7 @@ snapshots['AttendanceTestCase::test_user_attend_model_is_populated_with_new_even
                 {
                     'node': {
                         'event': {
-                            'id': 'RXZlbnROb2RlOjE0',
+                            'id': 'RXZlbnROb2RlOjIw',
                             'title': 'Test Event 2'
                         },
                         'id': 'QXR0ZW5kTm9kZTo5',

--- a/server/graphql_schemas/tests/events/base.py
+++ b/server/graphql_schemas/tests/events/base.py
@@ -1,6 +1,7 @@
-import datetime
 import pytz
 
+from datetime import datetime, timedelta
+from django.utils import timezone
 from django.test import RequestFactory
 from django.contrib.auth.models import User
 from snapshottest.django import TestCase
@@ -13,8 +14,10 @@ from graphql_schemas.views import DRFAuthenticatedGraphQLView as DRF
 
 from google.oauth2.credentials import Credentials
 
+current_date = timezone.now()
+past_date = current_date - timedelta(hours=24)
 
-date = datetime.datetime(2018, 11, 20, 20, 8, 7, 127325, tzinfo=pytz.UTC)
+date = datetime(2018, 11, 20, 20, 8, 7, 127325, tzinfo=pytz.UTC)
 request_factory = RequestFactory()
 
 

--- a/server/graphql_schemas/tests/events/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/events/snapshots/snap_test_mutations.py
@@ -24,7 +24,7 @@ snapshots['MutateEventTestCase::test_create_event_with_calendar_unauthorizd 1'] 
     },
     'errors': [
         {
-            'AuthUrl': 'https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=1023621061664-1b7grp47bee4qu0k0a5114dvm1icl65k.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fv1%2Foauthcallback&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar&state=3BidNiT8qjMlJg9b1MRH39DVQEPMh6&prompt=consent&included_granted_scopes=true&login_hint=testemailcreatorId%40email.com&access_type=offline',
+            'AuthUrl': 'https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=1023621061664-1b7grp47bee4qu0k0a5114dvm1icl65k.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fv1%2Foauthcallback&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar&state=ZITN2SxIFY590CerKI8yvgR10UnTWp&prompt=consent&included_granted_scopes=true&login_hint=testemailcreatorId%40email.com&access_type=offline',
             'message': 'Calendar API not authorized'
         }
     ]
@@ -244,6 +244,16 @@ snapshots['MutateEventTestCase::test_validate_invite_link_unauthorized_user 1'] 
             'event': None,
             'isValid': False,
             'message': 'Forbidden: Unauthorized access'
+        }
+    }
+}
+
+snapshots['MutateEventTestCase::test_validate_invite_link_expired_event 1'] = {
+    'data': {
+        'validateEventInvite': {
+            'event': None,
+            'isValid': False,
+            'message': 'Expired Invite: Event has ended'
         }
     }
 }

--- a/server/graphql_schemas/tests/events/snapshots/snap_test_queries.py
+++ b/server/graphql_schemas/tests/events/snapshots/snap_test_queries.py
@@ -45,7 +45,7 @@ snapshots['QueryEventTestCase::test_get_event_list 1'] = {
                         'description': 'test description default',
                         'id': 'RXZlbnROb2RlOjU=',
                         'socialEvent': {
-                            'id': 'Q2F0ZWdvcnlOb2RlOjQ0',
+                            'id': 'Q2F0ZWdvcnlOb2RlOjQ1',
                             'name': 'social event'
                         },
                         'startDate': '2018-11-20T20:08:07.127325+00:00',
@@ -100,7 +100,7 @@ snapshots['QueryEventTestCase::test_filter_event_list_by_valid_venue_is_successf
                         'description': 'test description default',
                         'id': 'RXZlbnROb2RlOjU=',
                         'socialEvent': {
-                            'id': 'Q2F0ZWdvcnlOb2RlOjQz',
+                            'id': 'Q2F0ZWdvcnlOb2RlOjQ0',
                             'name': 'social event'
                         },
                         'startDate': '2018-11-20T20:08:07.127325+00:00',

--- a/server/graphql_schemas/tests/users/snapshots/snap_test_queries.py
+++ b/server/graphql_schemas/tests/users/snapshots/snap_test_queries.py
@@ -11,7 +11,7 @@ snapshots['QueryAndelaUserTestCase::test_query_users_by_id 1'] = {
     'data': {
         'user': {
             'googleId': '344445',
-            'id': 'QW5kZWxhVXNlck5vZGU6MTAz',
+            'id': 'QW5kZWxhVXNlck5vZGU6MTEy',
             'userPicture': 'https://lh5.googleusercontent.com'
         }
     }
@@ -24,14 +24,14 @@ snapshots['QueryAndelaUserTestCase::test_query_users_list 1'] = {
                 {
                     'node': {
                         'googleId': '123233',
-                        'id': 'QW5kZWxhVXNlck5vZGU6MTA0',
+                        'id': 'QW5kZWxhVXNlck5vZGU6MTEz',
                         'userPicture': 'https://lh5.googleusercontent.com'
                     }
                 },
                 {
                     'node': {
                         'googleId': '344445',
-                        'id': 'QW5kZWxhVXNlck5vZGU6MTA1',
+                        'id': 'QW5kZWxhVXNlck5vZGU6MTE0',
                         'userPicture': 'https://lh5.googleusercontent.com'
                     }
                 }


### PR DESCRIPTION
#### What Does This PR Do?
It restricts access to an event invite after the event end time has passed

#### Description Of Task To Be Completed
- While validating the invite link, assert that the end time of the event associated with the invite is in the future

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
Run command `tox`

#### What are the relevant pivotal tracker stories?
#159750242 User cannot access event invite after event end time

#### Screenshot(s)
N/A
