### PR TITLE
Bug #160174080: Fix text container misbehaving

### DIFF
--- a/client/assets/components/navbar.scss
+++ b/client/assets/components/navbar.scss
@@ -41,7 +41,7 @@
   padding: 0;
   height: rem(70px);
   .nav-profile {
-    width: rem(183.5px);
+    min-width: rem(183.5px);
     margin: 0;
     &__list-menus {
       @include column-flex;


### PR DESCRIPTION
#### What Does This PR Do?

Fix misbehaving when a name was long enough to past the text container

#### How can this be manually tested?

Supposing you have the app setup and running following the README.md

- run `scripts start.sh` while in the project root folder
- Navigate to `http://localhost:9000`.
- You should be able to see a navbar which once there is a long username automatically adjusts to it. Check the screenshot below.

#### What are the relevant pivotal tracker stories?

[160174080](https://www.pivotaltracker.com/n/projects/2174978/stories/160174080)

#### Screenshot(s)

<img width="1440" alt="screen shot 2018-09-03 at 10 13 44" src="https://user-images.githubusercontent.com/19430799/44972507-1512a780-af62-11e8-96d3-dc5eaa22484f.png">

