### PR TITLE
Bug #160226547: Add hover properties and adjust menu bar

### DIFF
--- a/client/assets/components/navbar.scss
+++ b/client/assets/components/navbar.scss
@@ -37,7 +37,6 @@
       display: block;
       position: absolute;
       bottom: 0;
-      margin: 0 auto;
       width: rem(70px);
       height: rem(6px);
       border-radius: rem(6px);

--- a/client/assets/components/navbar.scss
+++ b/client/assets/components/navbar.scss
@@ -3,21 +3,46 @@
 .navbar {
   overflow: hidden;
   box-shadow: 0rem 0.5rem 1rem 0rem rgba(0, 0, 0, 0.2);
-  background: #FFFFFF;
+  background: $white;
+  border: none;
+
   a {
-    font-size: 1.6rem;
+    @include centered-flex;
+    font-size: rem(20px);
     text-align: center;
     color: map-get($colors, silver);
-    padding: 0.9rem 1rem;
     text-decoration: none;
+    height: 100%;
+    margin: 0 rem(30.5px);
   }
+
   &__bottom-section {
-    height: 2.5rem;
-    text-align: center;
+    @include centered-flex;
+    height: rem(70px);
     border-top-style: solid;
     border-width: thin;
     border-color: map-get($colors, bonjour);
-    padding-top: 0.625rem;
+
+    .link__container{
+      @include centered-flex;
+      height: 100%;
+    }
+
+    .link__container--active{
+      color: $blue;
+    }
+
+    .link__container a:hover::after, .link__container--active::after {
+      content: '';
+      display: block;
+      position: absolute;
+      bottom: 0;
+      margin: 0 auto;
+      width: rem(70px);
+      height: rem(6px);
+      border-radius: rem(6px);
+      background-color: $blue;
+    }
   }
 }
 

--- a/client/components/common/Header.js
+++ b/client/components/common/Header.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import NavBar from './NavBar';
@@ -36,4 +37,4 @@ Header.propTypes = {
   signOut: PropTypes.func.isRequired,
 };
 
-export default connect(null, { signOut })(Header);
+export default withRouter(connect(null, { signOut })(Header));

--- a/client/components/common/NavBar.js
+++ b/client/components/common/NavBar.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 // components
@@ -52,8 +52,16 @@ const NavBar = (props) => {
       </nav>
       <div className="navbar">
         <div className="navbar__bottom-section">
-            <Link to="#dashboard">Dashboard</Link>
-            <Link to="#groups">My Groups</Link>
+          <div className="link__container">
+            <NavLink to="/events" activeClassName="link__container--active">
+              <span>Dashboard</span>
+            </NavLink>
+          </div>
+          <div className="link__container">
+            <NavLink to="/groups" activeClassName="link__container--active">
+              <span>My Groups</span>
+            </NavLink>
+          </div>
         </div>
       </div>
     </Fragment>

--- a/client/components/common/NavBar.js
+++ b/client/components/common/NavBar.js
@@ -11,6 +11,22 @@ import LogoReplacement from '../../assets/icons/LogoReplacement';
 // assets
 import '../../assets/components/navbar.scss';
 
+const NavMenu = ({
+  to,
+  children,
+}) => (
+  <div className="link__container">
+    <NavLink to={to} activeClassName="link__container--active">
+      <span>{children}</span>
+    </NavLink>
+  </div>
+);
+
+NavMenu.propTypes = {
+  to: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
 const NavBar = (props) => {
   const {
     signOut,
@@ -52,16 +68,8 @@ const NavBar = (props) => {
       </nav>
       <div className="navbar">
         <div className="navbar__bottom-section">
-          <div className="link__container">
-            <NavLink to="/events" activeClassName="link__container--active">
-              <span>Dashboard</span>
-            </NavLink>
-          </div>
-          <div className="link__container">
-            <NavLink to="/groups" activeClassName="link__container--active">
-              <span>My Groups</span>
-            </NavLink>
-          </div>
+          <NavMenu to="/dashboard">Dashboard</NavMenu>
+          <NavMenu to="/groups">Groups</NavMenu>
         </div>
       </div>
     </Fragment>


### PR DESCRIPTION
Adjust menu bar to match mockup

#### What Does This PR Do?

It adjusts MenuBar to match mockup, see screenshot below 👇 

<img width="1440" alt="screen shot 2018-09-03 at 18 28 47" src="https://user-images.githubusercontent.com/19430799/44994417-3d70c500-afa7-11e8-9d68-92a2e7f72308.png">

#### How can this be manually tested?

Supposing you have the app setup and running following the README.md

- run `scripts start.sh` while in the project root folder
- Navigate to `http://localhost:9000`.
- You should be able to see a MenuBar with the behavior demonstrated below 

#### What are the relevant pivotal tracker stories?

[#160226547](https://www.pivotaltracker.com/n/projects/2174978/stories/160226547)

#### Screenshot(s)/Demo

![navbar_bahaves](https://user-images.githubusercontent.com/19430799/44994500-93456d00-afa7-11e8-8be1-17c85274fc8b.gif)

