### PR TITLE
#160158027 Handle database error from multiple JoinCategory queries

### DIFF
--- a/server/graphql_schemas/interest/schema.py
+++ b/server/graphql_schemas/interest/schema.py
@@ -5,6 +5,7 @@ from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
 from graphql import GraphQLError
 from graphql_relay import from_global_id
+from django.db import IntegrityError
 
 from api.models import Interest, Category, AndelaUserProfile
 
@@ -28,11 +29,14 @@ class JoinCategory(relay.ClientIDMutation):
         category_id = input.get('category_id')
         user = AndelaUserProfile.objects.get(user=info.context.user)
         user_category = Category.objects.get(pk=from_global_id(category_id)[1])
-        joined_category = Interest(
-            follower=user,
-            follower_category=user_category
-        )
-        joined_category.save()
+        try:
+            joined_category = Interest(
+                follower=user,
+                follower_category=user_category
+            )
+            joined_category.save()
+        except IntegrityError:
+            raise GraphQLError('User has already shown interest in this category')
 
         return JoinCategory(joined_category=joined_category)
 

--- a/server/graphql_schemas/interest/schema.py
+++ b/server/graphql_schemas/interest/schema.py
@@ -36,7 +36,9 @@ class JoinCategory(relay.ClientIDMutation):
             )
             joined_category.save()
         except IntegrityError:
-            raise GraphQLError('User has already shown interest in this category')
+            raise GraphQLError(
+                'User has already shown interest in this category'
+            )
 
         return JoinCategory(joined_category=joined_category)
 

--- a/server/graphql_schemas/tests/category/test_mutations.py
+++ b/server/graphql_schemas/tests/category/test_mutations.py
@@ -1,5 +1,4 @@
 import logging
-from django.db import transaction
 
 from graphql_relay import to_global_id
 from api.models import Category

--- a/server/graphql_schemas/tests/interest/snapshots/snap_test_mutations.py
+++ b/server/graphql_schemas/tests/interest/snapshots/snap_test_mutations.py
@@ -106,3 +106,23 @@ snapshots['InterestTestCase::test_user_cannot_unjoin_category_they_do_not_belong
         }
     ]
 }
+
+snapshots['InterestTestCase::test_user_cannot_join_same_category_twice 1'] = {
+    'data': {
+        'joinCategory': None
+    },
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 13,
+                    'line': 3
+                }
+            ],
+            'message': 'User has already shown interest in this category',
+            'path': [
+                'joinCategory'
+            ]
+        }
+    ]
+}

--- a/server/graphql_schemas/tests/interest/test_mutations.py
+++ b/server/graphql_schemas/tests/interest/test_mutations.py
@@ -1,4 +1,7 @@
 from .base import BaseEventTestCase
+from graphql_relay import to_global_id
+from django.db import transaction
+from api.models import Interest
 
 
 class InterestTestCase(BaseEventTestCase):
@@ -8,21 +11,21 @@ class InterestTestCase(BaseEventTestCase):
 
     def test_user_can_join_and_unjoin_category(self):
         # Test for joining a category
-        query = '''
-        mutation{
-            joinCategory(input:{
-                categoryId:"Q2F0ZWdvcnlOb2RlOjI="
-            }){
-                joinedCategory{
+        query = f'''
+        mutation{{
+            joinCategory(input:{{
+                categoryId:"{to_global_id("CategoryNode", self.category2.id)}",
+            }}){{
+                joinedCategory{{
                 id
-                followerCategory{
+                followerCategory{{
                     id
                     name
                     description
-                }
-                }
-            }
-            }
+                }}
+                }}
+            }}
+            }}
         '''
 
         self.request.user = self.user2
@@ -30,26 +33,52 @@ class InterestTestCase(BaseEventTestCase):
         self.assertMatchSnapshot(result)
 
         # Tests unjoining a category
-        query = '''
-        mutation{
-            unjoinCategory(input:{
-                categoryId:"Q2F0ZWdvcnlOb2RlOjI="
-            }){
-                unjoinedCategory{
+        query = f'''
+        mutation{{
+            unjoinCategory(input:{{
+                categoryId:"{to_global_id("CategoryNode", self.category2.id)}",
+            }}){{
+                unjoinedCategory{{
                 id
-                followerCategory{
+                followerCategory{{
                     id
                     name
                     description
-                }
-                }
-            }
-            }
+                }}
+                }}
+            }}
+            }}
         '''
 
         self.request.user = self.user2
         result = self.client.execute(query, context_value=self.request)
         self.assertMatchSnapshot(result)
+
+    def test_user_cannot_join_same_category_twice(self):
+        query = f'''
+        mutation{{
+            joinCategory(input:{{
+                categoryId:"{to_global_id("CategoryNode", self.category2.id)}",
+            }}){{
+                joinedCategory{{
+                id
+                followerCategory{{
+                    id
+                    name
+                    description
+                }}
+                }}
+            }}
+            }}
+        '''
+        with transaction.atomic():
+            Interest.objects.create(
+                follower=self.andela_user2,
+                follower_category=self.category2
+            )
+            self.request.user = self.user2
+            result = self.client.execute(query, context_value=self.request)
+            self.assertMatchSnapshot(result)
 
     def test_user_cannot_unjoin_category_they_do_not_belong_to(self):
         query = '''


### PR DESCRIPTION
#### What Does This PR Do?
It handles database constraint error from multiple `JoinCategory` queries.
#### Description Of Task To Be Completed
Handle database constraint error from multiple `JoinCategory` queries
#### Any Background Context You Want To Provide?
N/A
#### How can this be manually tested?
N/A
#### What are the relevant pivotal tracker stories?
#160158027
#### Screenshot(s)
