### PR TITLE
Add + icon to create button

### DIFF
--- a/client/assets/components/createEventBtn.scss
+++ b/client/assets/components/createEventBtn.scss
@@ -8,4 +8,10 @@
   right: rem(20px);
   border-radius: 50%;
   color: $white;
+  &__icon {
+    font-size: rem(48px);
+    position: absolute;
+    top: rem(2px);
+    left: rem(29px);
+  } 
 }

--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -126,7 +126,7 @@ class Dashboard extends Component {
             }
             className="create-event-btn"
           >
-            Create Event
+            <span className="create-event-btn__icon">+</span>
           </button>
         );
       }}


### PR DESCRIPTION
#### What Does This PR Do?
- Adds `+` icon to `create-event` button.

#### Description Of Task To Be Completed
- Adds `+` icon  to `create-event` button

#### Any Background Context You Want To Provide?
- None

#### How can this be manually tested?
- Login and view the create event button.

#### What are the relevant PT story?
https://www.pivotaltracker.com/story/show/160767501

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/33066681/46033935-13bf3f80-c108-11e8-812c-dc93246b9bc4.png)

