### PR TITLE
make event form hidable by click outside or close button

### DIFF
--- a/client/assets/components/_button.scss
+++ b/client/assets/components/_button.scss
@@ -1,3 +1,8 @@
 .btn-blue {
   background: #365DDB;
 }
+
+.close-picker-icon {
+  font-weight: 400;
+  font-size: 1em;
+}

--- a/client/components/common/Form/DateTimePicker.js
+++ b/client/components/common/Form/DateTimePicker.js
@@ -31,21 +31,42 @@ export default class DateTimePicker extends Component {
     fullDate: "",
   }
 
-  toggleClick = () => {
-    this.setState({
-      showPicker: !this.state.showPicker 
-    })
+  componentDidMount() {
+    document.addEventListener('click', this.toggleClick, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.toggleClick, false);
   }
 
   onDateSelect = (value) => {
     this.props.dateSelected(this.props.type, "date", value) 
   }
 
-
   getDateTime = () => {
     const { dateValue, timeValue } = this.props;
     const dateTime = `${dateValue}      ${timeValue}`
     return dateTime
+  }
+
+  togglePickerIcon = () => {
+    const { showPicker } = this.state;
+    if (showPicker) {
+      return (
+        <button id="calendar-button" className="close-picker-icon" type="button" > &times; </button>
+      );
+    }
+    return (
+      <button id="calendar-button" type="button" value="cal" > calendar_today </button>
+    );
+  }
+
+  toggleClick = (event) => {
+    const { showPicker } = this.state;
+    if (this.node.contains(event.target)) {
+      return this.setState({ showPicker: !showPicker });
+    }
+    return this.setState({ showPicker: false });
   }
 
   render() {
@@ -56,12 +77,12 @@ export default class DateTimePicker extends Component {
       dateValue,
     } = this.props;
     return (
-      <div className="time-picker-input-field">
+      <div className="time-picker-input-field" ref={node => this.node = node}>
         <div className="time-picker-label">{label}</div>
       <div className="time-picker">
         <div className="time-picker-header">
           <span>{this.getDateTime()}</span>
-          <button id="calendar-button" type="reset" value="cal" onClick={this.toggleClick} > calendar_today </button>
+          {this.togglePickerIcon()}
         </div>
         {this.state.showPicker &&
             <Picker 


### PR DESCRIPTION
#### What Does This PR Do?

- make the calendar on create event form hidable by click on a close button
- make the calendar on create-event form hidable by a click outside the calendar component

#### Description Of Task To Be Completed
make the calendar on create event form hidable by click on a close button or outside the calendar component 

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
- Log in to the app
- click on the create event floating button
- attempt to select a start date and end date of the event

#### What are the relevant pivotal tracker stories?
[#160922537](https://www.pivotaltracker.com/n/projects/2174978/stories/160922537)

#### Screenshot(s)
<img width="629" alt="screen shot 2018-10-07 at 9 14 25 am" src="https://user-images.githubusercontent.com/24938186/46579864-7fab7d00-ca11-11e8-9089-36da5564f20f.png">
<img width="607" alt="screen shot 2018-10-07 at 9 14 42 am" src="https://user-images.githubusercontent.com/24938186/46579867-8cc86c00-ca11-11e8-8c38-4682b846168d.png">

