### PR TITLE
Fix parse_body to support both GraphQLI and multi-part request

### DIFF
--- a/server/graphql_schemas/views.py
+++ b/server/graphql_schemas/views.py
@@ -13,9 +13,10 @@ from graphql.error.located_error import GraphQLLocatedError
 class DRFAuthenticatedGraphQLView(FileUploadGraphQLView, GraphQLView):
 
     def parse_body(self, request):
-        if isinstance(request, rest_framework.request.Request):
+        content_type = self.get_content_type(request)
+        if content_type != 'multipart/form-data':
             return request.data
-        return super(GraphQLView, self).parse_body(request)
+        return super(DRFAuthenticatedGraphQLView, self).parse_body(request)
 
     @classmethod
     def as_view(cls, *args, **kwargs):


### PR DESCRIPTION
#### What Does This PR Do?
 - Overwrite the parse_body method to return plain data when the request is not of type 'multipart-form-data`

#### Description Of Task To Be Completed
- The previous parse_body overwrite did not correctly cater for parsing multipart form data.

#### Any Background Context You Want To Provide?
- With the presence of the previous overwrites, one could not create an event.

#### How can this be manually tested?
- By creating an event using the frontend form and Any other GraphQL Client.

#### What are the relevant pivotal tracker stories?
- Fixes [ #161080460]

