### PR TITLE
#161084134 Landing page with no events should be instructive.

### DIFF
--- a/client/assets/components/_eventNotFound.scss
+++ b/client/assets/components/_eventNotFound.scss
@@ -21,4 +21,9 @@
     font-weight: 200;
     text-transform: uppercase;
   }
+  &__actions {
+    display: flex;
+    padding: 5%;
+    justify-content: space-around;
+  }
 }

--- a/client/assets/pages/_events-page.scss
+++ b/client/assets/pages/_events-page.scss
@@ -571,3 +571,7 @@ main {
 .timezone ul  {
   background-color: white;
 }
+
+.small-button {
+  width: 10vw;
+} 

--- a/client/components/EventNotFound.jsx
+++ b/client/components/EventNotFound.jsx
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types';
 
 const EventNotFound = (props) => {
   const {
-    statusMessage, mainMessage,
+    statusMessage,
+    mainMessage,
+    actions,
   } = props;
   return (
-
     <div className="no-events">
       <div className="no-events__container">
         <h1 className="no-events__status-message">
@@ -16,6 +17,9 @@ const EventNotFound = (props) => {
         <h3 className="no-events__main-message">
           {mainMessage}
         </h3>
+        <div className="no-events__actions">
+          {actions}
+        </div>
       </div>
     </div>
   );
@@ -25,11 +29,13 @@ const EventNotFound = (props) => {
 EventNotFound.propTypes = {
   mainMessage: PropTypes.string,
   statusMessage: PropTypes.string,
+  actions: PropTypes.arrayOf(PropTypes.object),
 };
 
 EventNotFound.defaultProps = {
   mainMessage: '',
   statusMessage: '',
+  actions: [],
 };
 
 

--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -13,10 +13,10 @@ import External from '../../components/External';
 import EventsPage from '../Event/EventsPage';
 import EventDetailsPage from '../Event/EventDetailsPage';
 import Invite from '../Invite';
-import ModalContextProvider, { ModalContextCreator } from '../../components/Modals/ModalContext';
+import ModalContextProvider from '../../components/Modals/ModalContext';
 import Modal from '../../components/Modals/ModalContainer';
 import LoadComponent from '../../utils/loadComponent';
-import { createEvent, updateEvent } from '../../actions/graphql/eventGQLActions';
+import { updateEvent } from '../../actions/graphql/eventGQLActions';
 import uploadImage from '../../actions/graphql/uploadGQLActions';
 import { getCategoryList } from '../../actions/graphql/categoryGQLActions';
 
@@ -108,40 +108,6 @@ class Dashboard extends Component {
     }
   };
 
-  renderCreateEventButton = categories => (
-    <ModalContextCreator.Consumer>
-      {
-        ({
-          activeModal,
-          openModal,
-        }) => {
-          // TODO: This should be removed, duplicate naming
-          const {
-            createEvent, uploadImage,
-          } = this.props;
-          if (activeModal) return null;
-          return (
-            <button
-              type="button"
-              onClick={() => openModal('CREATE_EVENT', {
-                modalHeadline: 'create event',
-                formMode: 'create',
-                formId: 'event-form',
-                categories,
-                createEvent,
-                uploadImage,
-                updateEvent: () => '',
-              })}
-              className="create-event-btn"
-            >
-              <span className="create-event-btn__icon">+</span>
-            </button>
-          );
-        }
-      }
-    </ModalContextCreator.Consumer>
-  );
-
   /**
    * Renders Dashboard component
    *
@@ -203,7 +169,6 @@ class Dashboard extends Component {
           <Route path="/dashboard" render={() => <EventsPage />} />
           <Route path="*" component={NotFound} />
         </Switch>
-        {this.renderCreateEventButton(categories)}
         <Modal {...this.props} />
       </ModalContextProvider>
     );
@@ -213,8 +178,6 @@ class Dashboard extends Component {
 Dashboard.propTypes = {
   location: PropTypes.shape({ pathname: PropTypes.string.isRequired }).isRequired,
   loadActiveUser: PropTypes.func.isRequired,
-  createEvent: PropTypes.func.isRequired,
-  uploadImage: PropTypes.func.isRequired,
   getCategoryList: PropTypes.func.isRequired,
 };
 
@@ -222,7 +185,6 @@ const mapDispatchToProps = dispatch => bindActionCreators(
   {
     loadActiveUser,
     displayLoginErrorMessage,
-    createEvent,
     updateEvent,
     uploadImage,
     getCategoryList,
@@ -234,7 +196,6 @@ const mapDispatchToProps = dispatch => bindActionCreators(
 const mapStateToProps = state => ({
   activeUser: state.activeUser,
   socialClubs: state.socialClubs,
-  imageUploaded: state.uploadImage,
   categoryList: state.socialClubs.socialClubs || [],
   oauth: state.oauth,
   oauthCounter: 1,


### PR DESCRIPTION
#### What Does This PR Do?
This allows more intuitive instructions on the default landing page in the occasion that there are no events when filters are applied.

#### Description Of Task To Be Completed
. Move `add-event` button to the event page.
. Add buttons to browse past events or create a new event on the EventNotFound page.

#### How can this be manually tested?
Applying filters that result in no events been returned should show a new page with some useful message, as well as action buttons.

#### What are the relevant pivotal tracker stories?
[#161084134](https://www.pivotaltracker.com/story/show/161084134)

#### Screenshot(s)
![screen shot 2018-10-15 at 12 51 21 pm](https://user-images.githubusercontent.com/16901595/46950927-3fd23e80-d07e-11e8-9418-8e8cef38a662.png)

