### PR TITLE
 #161058166 Chore Allows database creation in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -45,7 +45,26 @@ function setup_client() {
 	fi
 }
 
+function create_db(){
+	if psql -lqtA | cut -d\| -f1 | grep -qxF "a_socials"; then
+		echo "You already have a database named a_socials."
+	else
+		echo "You need to create a database."
+		echo -e "\n\n\033[31mPlease provide a single argument for the username/dbname\033[0m\n"
+		read dbname
+		DBNAME=$dbname
+		echo -e "\n\n\033[31mPlease provide just one argument as the username\033[0m\n"
+		read dbuser
+		USERNAME_DBNAME=$dbuser
+		if ! psql -lqtA | grep  $USERNAME_DBNAME; then
+			createuser -P -s -e $DBNAME
+		fi
+		createdb --username=$USERNAME_DBNAME --owner=$USERNAME_DBNAME -W $DBNAME
+	fi
+}
+
 venv
+create_db
 setup_server
 setup_client
 exit 0


### PR DESCRIPTION
#### What Does This PR Do?
- Moves database creation into the setup script as a function.
- Remove previously use create_db scripts
#### How can this be manually tested?
- Run `bash scripts/setup.sh` from your terminal.
#### What are the relevant pivotal tracker stories?
Finishes [#161058166](https://www.pivotaltracker.com/story/show/161058166)
