### PR TITLE
Fix #161058778 and #161060549

### DIFF
--- a/client/assets/components/_event-card.scss
+++ b/client/assets/components/_event-card.scss
@@ -58,6 +58,7 @@
     height: rem(16px);
     text-align: center;
     text-transform: lowercase;
+    margin-bottom: rem(8px);
   }
   &:hover {
     box-shadow: 0 rem(4px) rem(10px) rgba(0, 0, 0, 0.679);

--- a/client/assets/components/common/form.scss
+++ b/client/assets/components/common/form.scss
@@ -14,7 +14,7 @@
   }
 
   .as-form-group__input--text_area {
-    height: rem(80px);
+    height: rem(100px);
     resize: none;
   }
 

--- a/client/assets/tools/variables.scss
+++ b/client/assets/tools/variables.scss
@@ -7,7 +7,7 @@ $grey: #dedede;
 $grey-2: #CCCCCC;
 $blue: #365edb;
 $danger: #db4437;
-$dark-grey: #A2A2A2
+$dark-grey: #A2A2A2;
 // aliases
 $border-radius: 5px;
 $box-shadow: #383434;


### PR DESCRIPTION
#### What Does This PR Do?
It allows the description to accommodate 3 lines without scrolling - #161060549
It adds space between tags and bottom of the event card - #161058778 
It fixes a missing semicolon error currently on develop.
#### Description Of Task To Be Completed
Allow description to accommodate 3 lines without scrolling.
Add space between tags and bottom of the event card.
#### Any Background Context You Want To Provide?

#### How can this be manually tested?

#### What are the relevant pivotal tracker stories?
#161058778
#161060549
#### Screenshot(s)
space between tags and bottom of the event card 
<img width="783" alt="screen shot 2018-10-18 at 1 33 50 pm" src="https://user-images.githubusercontent.com/25981851/47154531-80c68f00-d2da-11e8-9483-50bf23ed9fb0.png">

description accommodating 3 lines without scrolling
<img width="571" alt="screen shot 2018-10-18 at 1 30 04 pm" src="https://user-images.githubusercontent.com/25981851/47154334-f716c180-d2d9-11e8-843f-34cea933bac3.png">
