### PR TITLE
#161058605 Make event details page responsive

### DIFF
--- a/client/assets/pages/_event_details-page.scss
+++ b/client/assets/pages/_event_details-page.scss
@@ -2,7 +2,7 @@
   position: absolute;
   left: 2.5vw;
   width: 95vw;
-  top: 150px;
+  top: rem(150px);
 
   &__top{
     background-color: #FFF;
@@ -13,15 +13,15 @@
     width: 50%;
     max-height: 100%;
     float: left;
-    padding: 19px 19px 12px 19px;
+    padding: rem(19px) rem(19px) rem(12px) rem(19px);
     background-color: #FFF;
-    @media screen and (max-width: 480px) {
+    @media screen and (max-width: rem(480px)) {
       width: 100%;
     }
   }
   
   &__middle{
-    margin-top: 20px;
+    margin-top: rem(20px);
     width: 95vw;
     min-height: 50vh;
     background-color: #FFF;
@@ -33,47 +33,47 @@
   }
   &__picture{
     width: 90%;
-    margin: 28px 35px 48px 28px;
+    margin: rem(28px) rem(35px) rem(48px) rem(28px);
   }
   &__gallery-picture{
-    width: 84px;
-    height: 89px;
-    margin-bottom: 39px;
-    margin-left: 20px;
+    width: rem(84px);
+    height: rem(89px);
+    margin-bottom: rem(39px);
+    margin-left: rem(20px);
   }
   &__mini-gallery{
-    margin-left: 28px;
+    margin-left: rem(28px);
     max-width: 41vw;
     display: inline-flex;
   }
   &__event_title{
     font-family: DIN Pro;
     font-weight: bold;
-    font-size: 40px;
-    padding: 0 0 0 26px;
+    font-size: rem(40px);
+    padding: 0 0 0 rem(26px);
   }
   &__social_event{
-    font-size: 20px;
+    font-size: rem(20px);
     font-style: normal;
     font-weight: lighter;
-    padding: 0 0 0 26px;
-    margin-top: -15px;
+    padding: 0 0 0 rem(26px);
+    margin-top: rem(-15px);
     color: #797979;
   }
   &__rsvp_button{
-    margin: 0 0 0 26px;
+    margin: 0 0 0 rem(26px);
     background-color: #3359DB;
     font-size: 1.25em;
     color: white;
-    width: 147px;
-    height: 41px;
+    width: rem(147px);
+    height: rem(41px);
   }
   &__location_time h5 {
     font-size: 1.25rem;
     font-style: normal;
     font-weight: lighter;
     text-decoration: underline;
-    line-height: 10px;
+    line-height: rem(10px);
   
   }
   &__location_time p {
@@ -86,8 +86,8 @@
     font-size: 1.25rem;
     font-style: normal;
     font-weight: bolder;
-    line-height: 7px;
-    padding-top: 19px;
+    line-height: rem(7px);
+    padding-top: rem(19px);
     margin-bottom: .5rem; 
   }
   &__description article, &__attending p, &__tags p{
@@ -95,7 +95,7 @@
     font-size: 1.2rem;
     word-break: break-all;
     font-weight: lighter;
-    padding: 19px 0 20px 0;
+    padding: rem(19px) 0 rem(20px) 0;
   }
   &__edit {
     color: #365edb;
@@ -103,6 +103,6 @@
     font-size: large;
     width: rem(49px);
     height: rem(42px);
-    margin: 0 0 0 26px;    
+    margin: 0 0 0 rem(26px);    
   }
 }

--- a/client/assets/pages/_event_details-page.scss
+++ b/client/assets/pages/_event_details-page.scss
@@ -1,3 +1,4 @@
+@import '../tools/functions.scss';
 .event-details{
   position: absolute;
   left: 2.5vw;
@@ -15,7 +16,7 @@
     float: left;
     padding: rem(19px) rem(19px) rem(12px) rem(19px);
     background-color: #FFF;
-    @media screen and (max-width: rem(480px)) {
+    @media screen and (max-width: rem(840px)) {
       width: 100%;
     }
   }

--- a/client/assets/pages/_event_details-page.scss
+++ b/client/assets/pages/_event_details-page.scss
@@ -1,33 +1,38 @@
 .event-details{
-    &__top{
-    position: absolute;
-    width: 95vw;
-    height: 17vh;
-    left: 2.5vw;
-    top: 17vh;
+  position: absolute;
+  left: 2.5vw;
+  width: 95vw;
+  top: 150px;
+
+  &__top{
     background-color: #FFF;
-    display: inline-flex;
+    display: flex;
+    flex-wrap: wrap;
   }
   &__section{
     width: 50%;
     max-height: 100%;
     float: left;
-    padding: 19px;
+    padding: 19px 19px 12px 19px;
     background-color: #FFF;
+    @media screen and (max-width: 480px) {
+      width: 100%;
+    }
   }
   
   &__middle{
-    position: absolute;
+    margin-top: 20px;
     width: 95vw;
     min-height: 50vh;
-    left: 2.5vw;
-    top: 36vh;
     background-color: #FFF;
-    display: inline-flex;
+    display: flex;
+    flex-wrap: wrap;
+  }
+  &__img-container{
+    overflow: hidden;
   }
   &__picture{
-    height: 30vh;
-    max-width: 41vw;
+    width: 90%;
     margin: 28px 35px 48px 28px;
   }
   &__gallery-picture{
@@ -88,6 +93,7 @@
   &__description article, &__attending p, &__tags p{
     font-style: normal;
     font-size: 1.2rem;
+    word-break: break-all;
     font-weight: lighter;
     padding: 19px 0 20px 0;
   }

--- a/client/pages/Event/EventDetailsPage.jsx
+++ b/client/pages/Event/EventDetailsPage.jsx
@@ -191,12 +191,10 @@ class EventDetailsPage extends React.Component {
       return <NotFound />;
     }
     return (
-      <React.Fragment>
-        <div className="event-details">
-          {this.topSection()}
-          {this.middleSection()}
-        </div>
-      </React.Fragment>
+      <div className="event-details">
+        {this.topSection()}
+        {this.middleSection()}
+      </div>
     );
   }
 }

--- a/client/pages/Event/EventDetailsPage.jsx
+++ b/client/pages/Event/EventDetailsPage.jsx
@@ -76,7 +76,7 @@ class EventDetailsPage extends React.Component {
           <div className="event-details__social_event">{socialEvent.name}</div>
           {creator
             ? <div>
-            {this.renderCreateEventButton(eventData)}
+              {this.renderCreateEventButton(eventData)}
             </div>
             : <button type="submit" className="event-details__rsvp_button">
               {' '}
@@ -131,11 +131,11 @@ class EventDetailsPage extends React.Component {
           </div>
         </div>
         <div className="event-details__section">
-          <img src={featuredImage} alt="event img" className="event-details__picture" />
+          <div className="event-details__img-container">
+            <img src={featuredImage} alt="event img" className="event-details__picture" />
+          </div>
+          <br />
           <div className="event-details__mini-gallery">
-            <img src={featuredImage} alt="event img" className="event-details__gallery-picture" />
-            <img src={featuredImage} alt="event img" className="event-details__gallery-picture" />
-            <img src={featuredImage} alt="event img" className="event-details__gallery-picture" />
             <img src={featuredImage} alt="event img" className="event-details__gallery-picture" />
           </div>
         </div>
@@ -179,7 +179,7 @@ class EventDetailsPage extends React.Component {
         }
       }
     </ModalContextCreator.Consumer>
-  );  
+  );
 
   render() {
     const { updated } = this.state;
@@ -192,8 +192,10 @@ class EventDetailsPage extends React.Component {
     }
     return (
       <React.Fragment>
-        {this.topSection()}
-        {this.middleSection()}
+        <div className="event-details">
+          {this.topSection()}
+          {this.middleSection()}
+        </div>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
#### What Does This PR Do?
It makes event details page responsive
#### Description Of Task To Be Completed
Ensure that the view event details page is responsive.
#### Any Background Context You Want To Provide?

#### How can this be manually tested?
N/A
#### What are the relevant pivotal tracker stories?
#161058605
#### Screenshot(s)
Before
<img width="1278" alt="screen shot 2018-10-22 at 2 06 02 pm" src="https://user-images.githubusercontent.com/25981851/47357250-10df4c80-d6be-11e8-8d52-c1925ad824d4.png">
Sketch on figma
<img width="733" alt="screen shot 2018-10-23 at 12 21 00 pm" src="https://user-images.githubusercontent.com/25981851/47357277-22c0ef80-d6be-11e8-9212-db0dba601e70.png">
Now

web
<img width="1280" alt="screen shot 2018-10-23 at 12 18 41 pm" src="https://user-images.githubusercontent.com/25981851/47357315-408e5480-d6be-11e8-92ff-e30f980b4622.png">

mobile
<img width="455" alt="screen shot 2018-10-23 at 12 19 31 pm" src="https://user-images.githubusercontent.com/25981851/47357316-4126eb00-d6be-11e8-85ba-83fe5c4e8141.png">

