### PR TITLE
Fix authentication bug on staging.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "html-webpack-plugin": "3.2.0",
     "image-webpack-loader": "3.4.2",
     "jquery": "3.2.1",
+    "js-cookie": "^2.2.0",
     "jwt-decode": "2.2.0",
     "moment-timezone": "0.5.21",
     "node-sass": "4.5.3",

--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 // third-party imports
 import { Route, Redirect, Switch } from 'react-router-dom';
+import Cookies from 'js-cookie';
 
 // components
 import Header from '../../components/common/Header';
@@ -33,6 +34,7 @@ import isTokenExpired from '../../utils/isTokenExpired';
 
 // other routes
 const NotFound = LoadComponent(import('../../components/common/NotFound'));
+
 
 /**
  * Represents Dashboard component
@@ -163,8 +165,16 @@ class Dashboard extends Component {
       }))
       : [];
 
+
     if (search.split('?token=')[1]) {
       localStorage.setItem('token', search.split('?token=')[1]);
+    }
+
+    if (!localStorage.getItem('token')) {
+      const token = Cookies.get('jwt-token');
+      if (token) {
+        localStorage.setItem('token', token);
+      }
     }
 
     if (isTokenExpired() || !isLoggedIn()) {


### PR DESCRIPTION
#### What Does This PR Do?
Fixes authentication problem that arises on staging because the token is returned in the cookies instead of a query param.

#### Description Of Task To Be Completed
In the case that the token is not already in localStorage, add a check for the token in the cookies and update localStorage if it exists.

#### Any Background Context You Want To Provide?
This bug was introduced as a result of the Andela api working in multiple ways for localhost and the staging-socials.andela.com URL. In the former, the token was appended as a query param and the latter in the cookies as `jwt-token`

Also, removing the token from localStorage, adding it as `jwt-token` in the cookies and refreshing the landing page, should sign in the user and store the token in localstorage.

#### How can this be manually tested?
Authentication should now work on both development and staging environments.

#### What are the relevant pivotal tracker stories?
[#161449558](https://www.pivotaltracker.com/story/show/161449558)