### PR TITLE
#161058875 Make load more button only visible

### DIFF
--- a/client/Graphql/Queries/EventListGQL.js
+++ b/client/Graphql/Queries/EventListGQL.js
@@ -36,6 +36,10 @@ const EVENT_LIST_GQL = (after = '', first = 1, title, startDate, venue,
           }
           cursor
         }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
       }
     }`,
   variables: {

--- a/client/actions/graphql/eventGQLActions.js
+++ b/client/actions/graphql/eventGQLActions.js
@@ -28,6 +28,7 @@ export const getEventsList = ({
   .then(data => dispatch({
     type: after ? LOAD_MORE_EVENTS : GET_EVENTS,
     payload: data.data.eventsList.edges,
+    pageInfo: data.data.eventsList.pageInfo,
     error: false,
   }))
   .catch(error => handleError(error, dispatch));

--- a/client/assets/pages/_events-page.scss
+++ b/client/assets/pages/_events-page.scss
@@ -29,7 +29,7 @@
   }
   &__footer {
     grid-column: event-gallery-start/event-gallery-end;
-    height: 100%;
+    height: 80%;
     width: 100%;
     margin-top: rem(29.69px);
     display: flex;

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -65,8 +65,6 @@ class EventsPage extends React.Component {
   }
 
   /**
-   *
-   *
    * @param {*} prevProps
    * @param {*} prevState
    * @returns
@@ -195,6 +193,7 @@ class EventsPage extends React.Component {
 
   render() {
     const { categoryList, eventList } = this.state;
+    const { lastPage } = this.props;
     const catList = Array.isArray(categoryList) ? categoryList.map(item => ({
       id: item.node.id,
       title: item.node.name,
@@ -209,7 +208,7 @@ class EventsPage extends React.Component {
         </div>
         {this.renderEventGallery()}
         <div className="event__footer">
-          { eventList.length >= 9
+          { lastPage
             && <button ref={this.btnRef} onClick={this.loadMoreEvents}
               type="button" className="btn-blue event__load-more-button" id="load-more-btn">
             Load more
@@ -221,8 +220,9 @@ class EventsPage extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  events: state.events,
+  events: state.events.events,
   socialClubs: state.socialClubs,
+  lastPage: state.events.pageInfo.hasNextPage,
 });
 
 export default connect(mapStateToProps, {

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -29,6 +29,7 @@ class EventsPage extends React.Component {
       lastEventItemCursor: '',
     };
     this.getFilteredEvents = this.getFilteredEvents.bind(this);
+    this.btnRef = React.createRef();
   }
 
   /**
@@ -45,18 +46,56 @@ class EventsPage extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  /**
+   * @param {*} prevProps
+   * @param {*} prevState
+   * @param {*} snapshot
+   *
+   * @memberof EventsPage
+   */
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    // snapshot is the returned value from getSnapshotBeforeUpdate
+    // get the btn's current position and push it into view
+    if (this.btnRef.current !== null) {
+      if (snapshot !== null) {
+        const btn = this.btnRef.current;
+        btn.scrollIntoView();
+      }
+    }
+  }
+
+  /**
+   *
+   *
+   * @param {*} prevProps
+   * @param {*} prevState
+   * @returns
+   * @memberof EventsPage
+   */
+  getSnapshotBeforeUpdate(prevProps, prevState) {
+    // capture the button scroll position before update occurs
+    const { events } = this.props;
+    if (this.btnRef.current !== null) {
+      if (prevState.eventList.length < events.length) {
+        const button = this.btnRef.current;
+        return button.scrollHeight - button.scrollTop;
+      }
+    }
+    return null;
+  }
+
+  static getDerivedStateFromProps(props, state) {
     const {
       events, socialClubs,
-    } = nextProps;
+    } = props;
 
     const eventLength = events.length;
     const lastEventItemCursor = eventLength ? events[eventLength - 1].cursor : '';
-    this.setState({
+    return {
       eventList: events,
       categoryList: socialClubs.socialClubs,
       lastEventItemCursor,
-    });
+    };
   }
 
   getFilteredEvents(filterDate, filterLocation, filterCategory) {
@@ -135,6 +174,7 @@ class EventsPage extends React.Component {
       category: selectedCategory,
       after: lastEventItemCursor,
     });
+    this.btnRef.current.scrollIntoView();
   }
 
   /**
@@ -154,7 +194,7 @@ class EventsPage extends React.Component {
   }
 
   render() {
-    const { categoryList } = this.state;
+    const { categoryList, eventList } = this.state;
     const catList = Array.isArray(categoryList) ? categoryList.map(item => ({
       id: item.node.id,
       title: item.node.name,
@@ -169,9 +209,11 @@ class EventsPage extends React.Component {
         </div>
         {this.renderEventGallery()}
         <div className="event__footer">
-          <button onClick={this.loadMoreEvents} type="button" className="btn-blue event__load-more-button">
+          { eventList.length >= 9
+            && <button ref={this.btnRef} onClick={this.loadMoreEvents}
+              type="button" className="btn-blue event__load-more-button" id="load-more-btn">
             Load more
-          </button>
+          </button>}
         </div>
       </div>
     );

--- a/client/reducers/eventReducers.js
+++ b/client/reducers/eventReducers.js
@@ -18,20 +18,35 @@ import initialState from './initialState';
 
 /**
  * Reducer for one events
- * @param {object} [state=initialState.events]
+ * @param {object} [state=initialState.eventsDetails]
  * @param {object} action
  * @returns {array} new state of the events
  */
-export const events = (state = initialState.events, action) => {
+export const events = (state = initialState.eventsDetails, action) => {
   switch (action.type) {
     case GET_EVENTS:
-      return [...action.payload];
-    case LOAD_MORE_EVENTS:
-      return [...state, ...action.payload];
+      return {
+        ...state, events: action.payload, pageInfo: action.pageInfo,
+      };
+
+    case LOAD_MORE_EVENTS: {
+      const loadedEvents = [...state.events, ...action.payload];
+      return {
+        events: loadedEvents, pageInfo: action.pageInfo,
+      };
+    }
 
     case CREATE_EVENT: {
       const newEvents = { node: action.payload.createEvent.newEvent };
-      return [...state, newEvents];
+      const updatedEvents = [...state.events, newEvents];
+      return {
+        ...state,
+        events: updatedEvents,
+        pageInfo: {
+          ...state.pageInfo,
+          hasNextPage: state.pageInfo.hasNextPage || updatedEvents.length > 9,
+        },
+      };
     }
 
     case UPDATE_EVENT: {
@@ -45,6 +60,7 @@ export const events = (state = initialState.events, action) => {
         return item;
       });
       return {
+        ...state,
         events: updated,
         status: 'updated',
       };
@@ -67,11 +83,11 @@ export const events = (state = initialState.events, action) => {
 
 /**
  * Reducer for uploading an image
- * @param {object} [state=initialState.events]
+ * @param {object} [state=initialState.eventsDetails.events]
  * @param {object} action
  * @param {array}
  */
-export const uploadImage = (state = initialState.events, action) => {
+export const uploadImage = (state = initialState.eventsDetails.events, action) => {
   switch (action.type) {
     case UPLOAD_IMAGE: {
       const imageUploaded = {

--- a/client/reducers/eventReducers.js
+++ b/client/reducers/eventReducers.js
@@ -67,7 +67,7 @@ export const events = (state = initialState.eventsDetails, action) => {
     }
 
     case DEACTIVATE_EVENT: {
-      return state.filter(item => item.node.id !== action.payload.id);
+      return state.events.filter(item => item.node.id !== action.payload.id);
     }
 
     case SIGN_OUT:

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -1,7 +1,10 @@
 export default {
   activeUser: {},
   event: {},
-  events: [],
+  eventsDetails: {
+    events: [],
+    pageInfo: {},
+  },
   subscribedEvents: [],
   redirectUrl: '',
   interest: {},


### PR DESCRIPTION
#### What Does This PR Do?
This PR ensures the load mote button is always fixed
#### Description Of Task To Be Completed
Make the load more button visible for only 9 or more events on the dashboard
Make the load more button position fixed
#### Any Background Context You Want To Provide?
N/A
#### How can this be manually tested?
* Login to the app
* Add events less than 9 the load more button should not be visible 
* Add as many events greater than 9 the load more button should be visible
* You should see the load more button without needing to scroll down the page
#### What are the relevant pivotal tracker stories?
[161058875](https://www.pivotaltracker.com/n/projects/2174978/stories/161058875)
#### Screenshot(s)
<img width="1440" alt="screen shot 2018-10-25 at 10 05 37 pm" src="https://user-images.githubusercontent.com/29184825/47530619-08943680-d8a3-11e8-9de6-bc9bd02dec24.png">
