### PR TITLE
#161750629 Feature Persisting redirect url

### DIFF
--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -178,7 +178,10 @@ class Dashboard extends Component {
     }
 
     if (isTokenExpired() || !isLoggedIn()) {
-      return <Redirect to="/login" />;
+      return <Redirect to={{
+        pathname: '/login',
+        state: {"previousLocation": window.location.href}
+      }} />;
     }
 
     if (search === '?error=failed+to+create+user+token') {

--- a/client/pages/Login/index.js
+++ b/client/pages/Login/index.js
@@ -19,7 +19,8 @@ dotenv.config();
  * @memberof LoginPage
  */
 const Login = (props) => {
-  const redirectUrl = `${process.env.ANDELA_API_BASE_URL}/login?redirect_url=${process.env.FRONTEND_BASE_URL}`;
+  const previousLocation = props.location.state ? props.location.state.previousLocation : null
+  const redirectUrl = `${process.env.ANDELA_API_BASE_URL}/login?redirect_url=${previousLocation ? previousLocation : process.env.FRONTEND_BASE_URL}`;
   if (isLoggedIn()) {
     return (<Redirect to="/events" />);
   }


### PR DESCRIPTION
#### What Does This PR Do?    
 - In the case that a user is redirected to the login page from within the app, they should be taken back to the previous page they were on.

#### Description Of Task To Be Completed
- The task involves fetching the link to the page in which the user was on before being redirected for authentication and making it the redirect URL on authentication instead of the default `/event` endpoint.

#### Any Background Context You Want To Provide?
- The URL is passed as a property in the redirect and is checked before creating the redirectUrl.
- If there is a previous page i.e page the unauthenticated user tried to view then they were redirected to log in then that page will be the final destination for the user.
#### How can this be manually tested?
- When logged out try to view any page protected by auth e.g `/dashboard` or use an invite link if one is sent to your email. 
#### What are the relevant pivotal tracker stories?
    Finishes [#161750629]
