### PR TITLE
feat(unattend-event): Add decline event functionality

### DIFF
--- a/client/Graphql/Mutations/UnAttendEventGQL.js
+++ b/client/Graphql/Mutations/UnAttendEventGQL.js
@@ -1,24 +1,25 @@
 import gql from 'graphql-tag';
 
-const UNATTEND_EVENT_GQL = (eventId, clientMutationId = '') => ({
+const UNATTEND_EVENT_GQL = (eventId, clientMutationId = '', status = 'declined') => ({
   mutation: gql`
-    mutation($input: UnsubscribeEventInput!){
-      unattendEvent(input: $input){
-        unsubscribedEvent{
+    mutation($input: AttendEventInput!){
+      attendEvent(input: $input){
+        newAttendance{
           id
           createdAt
           updatedAt
+          status
           event{
             createdAt
             updatedAt
             id
-            time
             title
             description
             venue
-            date
+            startDate
+            endDate
             featuredImage
-            active
+            active          
           }
         }
         clientMutationId
@@ -28,8 +29,8 @@ const UNATTEND_EVENT_GQL = (eventId, clientMutationId = '') => ({
     input: {
       eventId,
       clientMutationId,
+      status,
     },
   },
 });
-
 export default UNATTEND_EVENT_GQL;

--- a/client/actions/graphql/attendGQLActions.js
+++ b/client/actions/graphql/attendGQLActions.js
@@ -44,6 +44,13 @@ export const attendEvent = (eventId, clientMutationId = '') => dispatch => Clien
 
 export const unAttendEvent = (eventId, clientMutationId = '') => dispatch => Client.mutate(
   UNATTEND_EVENT_GQL(eventId, clientMutationId)
-).then(data => dispatch({ type: UNATTEND_EVENT, payload: data.data, error: false, }))
-.catch(error => handleError(error, dispatch));
-
+).then((data) => {
+  const { attendEvent: { newAttendance } } = data.data;
+  dispatch({ 
+    type: UNATTEND_EVENT,
+    payload: data.data,
+    error: false,
+  });
+  handleInformation(`'${newAttendance.status} action' was successful`);
+})
+  .catch(error => handleError(error, dispatch));

--- a/client/pages/Event/EventDetailsPage.jsx
+++ b/client/pages/Event/EventDetailsPage.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import durationConverter from '../../utils/durationConverter';
 import { getEvent, deactivateEvent } from '../../actions/graphql/eventGQLActions';
-import { attendEvent } from '../../actions/graphql/attendGQLActions';
+import { attendEvent, unAttendEvent } from '../../actions/graphql/attendGQLActions';
 import NotFound from '../../components/common/NotFound';
 
 // stylesheet
@@ -161,9 +161,17 @@ class EventDetailsPage extends React.Component {
   rsvpEvent() {
     const {
       attendEventAction,
-      event: { id },
+      unAttendEventAction,
+      event: {
+        id, attendSet: { edges },
+      },
     } = this.props;
-    attendEventAction(id);
+
+    if (edges.length > 0) {
+      unAttendEventAction(id);
+    } else {
+      attendEventAction(id);
+    }
   }
 
   renderCreateEventButton = eventData => (
@@ -173,7 +181,9 @@ class EventDetailsPage extends React.Component {
           activeModal,
           openModal,
         }) => {
-          const { categories, uploadImage, updateEvent } = this.props;
+          const {
+            categories, uploadImage, updateEvent 
+          } = this.props;
           if (activeModal) return null;
           return (
             <button type="button"
@@ -257,6 +267,7 @@ EventDetailsPage.propTypes = {
   getEventAction: PropTypes.func,
   deactivateEventAction: PropTypes.func,
   attendEventAction: PropTypes.func,
+  unAttendEventAction: PropTypes.func,
   history: PropTypes.shape({ push: PropTypes.func.isRequired }),
   events: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.object),
@@ -287,20 +298,21 @@ EventDetailsPage.defaultProps = {
   getEventAction: () => null,
   deactivateEventAction: () => null,
   attendEventAction: () => null,
+  unAttendEventAction: () => null,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   getEventAction: getEvent,
   deactivateEventAction: deactivateEvent,
   attendEventAction: attendEvent,
+  unAttendEventAction: unAttendEvent,
 }, dispatch);
 
-const mapStateToProps = (state) => {
-  return {
-    event: state.event,
-    events: state.events,
-  };
-};
+const mapStateToProps = state => ({
+  event: state.event,
+  events: state.events,
+  activeUser: state.activeUser,
+});
 export default connect(
   mapStateToProps,
   mapDispatchToProps

--- a/client/reducers/eventReducers.js
+++ b/client/reducers/eventReducers.js
@@ -130,7 +130,7 @@ export const subscribedEvents = (state = initialState.subscribedEvents, action) 
     case UNATTEND_EVENT:
       return Object.assign({}, state, {
         subscribedEvents: state.subscribedEvents.filter(
-          item => item.event.id !== action.payload.unattendEvent.unsubscribedEvent.event.id
+          item => item.event.id !== action.payload.attendEvent.newAttendance.id
         ),
       });
 


### PR DESCRIPTION
#### What Does This PR Do?
Decline event functionality

#### Description Of Task To Be Completed
- Change mutation to un-attend an event
- Edit action that dispatches the un-attend event
- Edits component to call either attendEvent or unAttendEvent action.
- Any Background Context You Want To Provide?
- When a user clicks to attend an event, such a user cannot decline the event.

#### How can this be manually tested?
- Clone the app
- Switch to branch ft-decline-event-functionality-162235160
- Click to attend an event
- Click the button again to decline event.

#### What are the relevant github issues?
N/A

#### Screenshot(s)
<img width="1440" alt="screen shot 2019-01-24 at 9 20 57 am" src="https://user-images.githubusercontent.com/32069279/51673097-739df800-1fcd-11e9-9ace-f88254e9b020.png">
