### PR TITLE
#165020010 Fix webpack hot reload and enable browser logs

### DIFF
--- a/client/config/webpack.config.dev.js
+++ b/client/config/webpack.config.dev.js
@@ -40,7 +40,6 @@ module.exports = merge(webpackCommonConfig, {
         secure: false,
       },
     },
-    clientLogLevel: 'none',
     hot: true,
     inline: true,
     historyApiFallback: true,

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 volumes:
   postgres_data: {}
   postgres_backup: {}
+  a_socials_node_modules:
 
 services:
   database:
@@ -42,3 +43,6 @@ services:
       - server
     ports:
       - "9000:9000"
+    volumes:
+      - ../../client:/andela_social
+      - a_socials_node_modules:/andela_social/node_modules


### PR DESCRIPTION
#### What Does This PR Do?

- Fixes webpack-dev-server hot reload issue when running the client from Docker in development mode. Also enables browser logs for more debugging options in development.

#### Description Of Task To Be Completed

- [x] Use default clientloglevel in webpack dev config
- [x] Create bind mount for client directory
- [x] Create volume for node_modules

#### Any Background Context You Want To Provide?
*Current Behaviour on Develop Branch*

When running the client app as a Docker container, `webpack-dev-server` hot reload doesn't work and this makes it difficult to make changes that are instantly reflected to the codebase. Also, browser console logs are not visible which limits the easily available debugging options that can be employed.

#### How can this be manually tested?
- Setup the project with Docker as outlined in the README
- Run `make build` and then `make start`
- Visit `localhost:9000`  in a browser
- Try to edit the codebase in the client folder
- The browser should instantly reload the page
- Also try to log to the console, and the log should appear in the browser console. Note that console logging is only available in a development environment.

#### What are the relevant pivotal tracker stories?
[#165020010](https://www.pivotaltracker.com/story/show/165020010)

#### Screenshot(s)
 - N/A