### PR TITLE
#165057365: Fix dropdown item selection

### DIFF
--- a/client/components/common/CustomDropDown.js
+++ b/client/components/common/CustomDropDown.js
@@ -14,19 +14,8 @@ class CustomDropDown extends Component {
     this.state = {
       listOpen: false,
       headerTitle: this.props.title,
-      updated: false,
     };
     this.selectedItem = this.selectedItem.bind(this);
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (prevState.updated === false && prevState.headerTitle !== nextProps.title) {
-      return {
-        headerTitle: nextProps.title,
-        updated: true,
-      };
-    }
-    return null;
   }
 
   handleClickOutside() {
@@ -37,7 +26,8 @@ class CustomDropDown extends Component {
     this.setState(prevState => ({ listOpen: !prevState.listOpen }));
   }
 
-  selectedItem(item) {
+  selectedItem(event, item) {
+    event.preventDefault();
     this.setState({
       headerTitle: item.title,
       listOpen: false,
@@ -68,7 +58,13 @@ class CustomDropDown extends Component {
       </div>
        {listOpen && <ul className="cd-list">
          {list.map(item => (
-           <li className="dd-list-item" onClick={() => this.selectedItem(item)} key={item.id} >{item.title}</li>
+           <li
+            className="dd-list-item"
+            onClick={(event) => this.selectedItem(event, item)}
+            key={item.id}
+            >
+              {item.title}
+            </li>
          ))}
         </ul>}
       </div>


### PR DESCRIPTION
#### What Does This PR Do?
This PR fixes the bug to make the select dropdown populate instantly when an option is selected

#### Description Of Task To Be Completed
1. Make the select dropdown populate instantly when an option is selected

#### Any Background Context You Want To Provide?
- Before now, a user has to select an option twice before it is selected on the custom drop down 

#### How can this be manually tested?
- git pull this branch
- start the application
- select an option on the CustomDropDown element

#### What are the relevant pivotal tracker stories?
[#165057365](https://www.pivotaltracker.com/story/show/165057365)

#### Screenshot(s)
N/A