### PR TITLE
 #165058658: Fix custom dropdown visibility when it loses focus

### DIFF
--- a/client/components/common/CustomDropDown.js
+++ b/client/components/common/CustomDropDown.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import onClickOutside from 'react-onclickoutside';
 import FontAwesome from 'react-fontawesome';
 
 /**
@@ -84,4 +85,4 @@ CustomDropDown.propTypes = {
 
 CustomDropDown.defaultProps = { title: 'Please select' };
 
-export default CustomDropDown;
+export default onClickOutside(CustomDropDown);

--- a/client/package.json
+++ b/client/package.json
@@ -59,6 +59,7 @@
     "react-apollo": "2.1.4",
     "react-dom": "16.4.1",
     "react-fontawesome": "1.6.1",
+    "react-onclickoutside": "^6.8.0",
     "react-redux": "5.0.7",
     "react-redux-toastr": "7.3.0",
     "react-router-dom": "4.2.2",


### PR DESCRIPTION
#### What Does This PR Do?
This PR fixes custom dropdown visibility when it loses focus

#### Description Of Task To Be Completed
```
1. Import `react-onclickoutside `package inside the `customDtopDown` component 
2. Wrap the` customDropDown` component with `onClickOutside` object
3. add method handleClickOutside to close dropdown when user clicks outside
```
#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
- git pull this branch
- start the application
- click on the dropdown to open and click outside the dropdown

#### What are the relevant pivotal tracker stories?
[ #165058658](https://www.pivotaltracker.com/story/show/165058658)

#### Screenshot(s)
N/A