### PR TITLE
#161058875 Ensure that the loadmore button is not hidden on the events page

### DIFF
--- a/client/Graphql/Queries/EventListGQL.js
+++ b/client/Graphql/Queries/EventListGQL.js
@@ -36,6 +36,10 @@ const EVENT_LIST_GQL = (after = '', first = 1, title, startDate, venue,
           }
           cursor
         }
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+        }
       }
     }`,
   variables: {

--- a/client/actions/graphql/eventGQLActions.js
+++ b/client/actions/graphql/eventGQLActions.js
@@ -27,7 +27,7 @@ export const getEventsList = ({
 }) => dispatch => Client.query(EVENT_LIST_GQL(after, first, title, startDate, venue, category))
   .then(data => dispatch({
     type: after ? LOAD_MORE_EVENTS : GET_EVENTS,
-    payload: data.data.eventsList.edges,
+    payload: data.data.eventsList,
     error: false,
   }))
   .catch(error => handleError(error, dispatch));

--- a/client/assets/pages/_events-page.scss
+++ b/client/assets/pages/_events-page.scss
@@ -4,6 +4,7 @@
   &__container {
     background-color: rgba(244, 248, 249, 1);
     display: grid;
+    height: 10rem;
     grid-template-columns: [full-start] rem(30px) [sidebar-start] rem(330px) [sidebar-end] rem(30px) [event-gallery-start] auto [event-gallery-end] rem(36px) [full-end];
     grid-template-rows: auto rem(147.69px);
     @include mobile('600px') {
@@ -26,15 +27,19 @@
     grid-row-gap: rem(30px);
     align-content: start;
     justify-content: flex-start;
+    padding-bottom: 1rem;
   }
   &__footer {
     grid-column: event-gallery-start/event-gallery-end;
     height: 100%;
     width: 100%;
-    margin-top: rem(29.69px);
     display: flex;
     justify-content: center;
     align-items: center;
+
+    &--hidden {
+      display: none;
+    }
   }
   &__load-more-button {
     width: 16vw;

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -47,13 +47,13 @@ class EventsPage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const {
-      events, socialClubs,
+      events: { eventList, pageInfo: { hasNextPage } }, socialClubs,
     } = nextProps;
-
-    const eventLength = events.length;
-    const lastEventItemCursor = eventLength ? events[eventLength - 1].cursor : '';
+    const eventLength = eventList.length;
+    const lastEventItemCursor = eventLength ? eventList[eventLength - 1].cursor : '';
     this.setState({
-      eventList: events,
+      eventList,
+      hasNextPage,
       categoryList: socialClubs.socialClubs,
       lastEventItemCursor,
     });
@@ -154,7 +154,7 @@ class EventsPage extends React.Component {
   }
 
   render() {
-    const { categoryList } = this.state;
+    const { categoryList, hasNextPage } = this.state;
     const catList = Array.isArray(categoryList) ? categoryList.map(item => ({
       id: item.node.id,
       title: item.node.name,
@@ -168,7 +168,7 @@ class EventsPage extends React.Component {
           <Calendar dateSelected={this.getFilteredEvents} />
         </div>
         {this.renderEventGallery()}
-        <div className="event__footer">
+        <div className={`event__footer ${hasNextPage ? '' : 'event__footer--hidden'}`} >
           <button onClick={this.loadMoreEvents} type="button" className="btn-blue event__load-more-button">
             Load more
           </button>

--- a/client/reducers/eventReducers.js
+++ b/client/reducers/eventReducers.js
@@ -25,18 +25,22 @@ import initialState from './initialState';
 export const events = (state = initialState.events, action) => {
   switch (action.type) {
     case GET_EVENTS:
-      return [...action.payload];
+      const { edges, pageInfo } = action.payload;
+      return { eventList: edges, pageInfo };
+      
     case LOAD_MORE_EVENTS:
-      return [...state, ...action.payload];
+      const { eventList } = state;
+      const { edges: newEvents, pageInfo: newPageInfo } = action.payload;
+      return { eventList: [...eventList, ...newEvents], pageInfo: newPageInfo };
 
     case CREATE_EVENT: {
-      const newEvents = { node: action.payload.createEvent.newEvent };
-      return [...state, newEvents];
+      const newEvent = { node: action.payload.createEvent.newEvent };
+      return { ...state, eventList: [...(state.eventList), newEvent] };
     }
 
     case UPDATE_EVENT: {
-      const stateFormat = state.events || state;
-      const updated = stateFormat.map((item) => {
+      const stateFormat = state.eventList || state;
+      const updated = (stateFormat).map((item) => {
         let newItem = {};
         if (item.node.id === action.payload.updateEvent.updatedEvent.id) {
           newItem = { node: action.payload.updateEvent.updatedEvent };
@@ -44,14 +48,12 @@ export const events = (state = initialState.events, action) => {
         }
         return item;
       });
-      return {
-        events: updated,
-        status: 'updated',
-      };
+      return { ...state, eventList: [...updated], status: 'updated' };
     }
 
     case DEACTIVATE_EVENT: {
-      return state.filter(item => item.node.id !== action.payload.id);
+      const newEventList = state.eventList.filter(item => item.node.id !== action.payload.id);
+      return { ...state, eventList: [...newEventList] };
     }
 
     case SIGN_OUT:


### PR DESCRIPTION
#### What Does This PR Do?
This PR ensures that the load more button is visible when there are more events to be shown.

#### Description Of Task To Be Completed
- Ensure that when there are no events to be shown the "load more" button is not visible
- Ensure that when there are more events to be shown then the "load more" button becomes visible 

#### How can this be manually tested?
- Ensure docker is installed locally on machine
- Ensure the environment variables in .env.sample are added in .env file in the root directory
- To build and spin up the docker containers, run make build
- To spin up the containers at a different time after building, run make start

#### What are the relevant github issues?
[#161058875](https://www.pivotaltracker.com/story/show/161058875)

<img width="1440" alt="Screenshot 2019-04-09 at 8 54 12 AM" src="https://user-images.githubusercontent.com/25434963/55786318-edf9f680-5aab-11e9-9dc6-2cf2d13f5945.png">
<img width="1440" alt="Screenshot 2019-04-09 at 8 50 51 AM" src="https://user-images.githubusercontent.com/25434963/55786340-f6eac800-5aab-11e9-80de-7006a6d2ad8c.png">
<img width="1440" alt="Screenshot 2019-04-09 at 8 52 35 AM" src="https://user-images.githubusercontent.com/25434963/55786354-fc481280-5aab-11e9-85be-bf31a16b2efc.png">

