### PR TITLE
#165210835 fix display of create event button to only be visible on the dashboard

### DIFF
--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -213,10 +213,9 @@ class Dashboard extends Component {
           />
           <Route path="/invite/:inviteHash" component={Invite} />
           <Route path="/events" render={() => <EventsPage />} />
-          <Route path="/dashboard" render={() => <EventsPage />} />
+          <Route path="/dashboard" render={() => <EventsPage createEventBtn={() => this.renderCreateEventButton(categories)} />} />
           <Route path="*" component={NotFound} />
         </Switch>
-        {this.renderCreateEventButton(categories)}
         <Modal {...this.props} />
       </ModalContextProvider>
     );

--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -14,7 +14,7 @@ import External from '../../components/External';
 import EventsPage from '../Event/EventsPage';
 import EventDetailsPage from '../Event/EventDetailsPage';
 import Invite from '../Invite';
-import ModalContextProvider, { ModalContextCreator } from '../../components/Modals/ModalContext';
+import ModalContextProvider from '../../components/Modals/ModalContext';
 import Modal from '../../components/Modals/ModalContainer';
 import LoadComponent from '../../utils/loadComponent';
 import { createEvent, updateEvent } from '../../actions/graphql/eventGQLActions';
@@ -110,40 +110,6 @@ class Dashboard extends Component {
     }
   };
 
-  renderCreateEventButton = categories => (
-    <ModalContextCreator.Consumer>
-      {
-        ({
-          activeModal,
-          openModal,
-        }) => {
-          // TODO: This should be removed, duplicate naming
-          const {
-            createEvent, uploadImage,
-          } = this.props;
-          if (activeModal) return null;
-          return (
-            <button
-              type="button"
-              onClick={() => openModal('CREATE_EVENT', {
-                modalHeadline: 'create event',
-                formMode: 'create',
-                formId: 'event-form',
-                categories,
-                createEvent,
-                uploadImage,
-                updateEvent: () => '',
-              })}
-              className="create-event-btn"
-            >
-              <span className="create-event-btn__icon">+</span>
-            </button>
-          );
-        }
-      }
-    </ModalContextCreator.Consumer>
-  );
-
   /**
    * Renders Dashboard component
    *
@@ -213,7 +179,7 @@ class Dashboard extends Component {
           />
           <Route path="/invite/:inviteHash" component={Invite} />
           <Route path="/events" render={() => <EventsPage />} />
-          <Route path="/dashboard" render={() => <EventsPage createEventBtn={() => this.renderCreateEventButton(categories)} />} />
+          <Route path="/dashboard" render={() => <EventsPage createEvent={createEvent} categories={categories} uploadImage={uploadImage} />} />
           <Route path="*" component={NotFound} />
         </Switch>
         <Modal {...this.props} />

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import Calendar from '../../components/common/Calendar';
 import EventFilter from '../../components/filter/EventFilter';
@@ -8,7 +9,6 @@ import formatDate from '../../utils/formatDate';
 import { getEventsList, createEvent } from '../../actions/graphql/eventGQLActions';
 import { getCategoryList } from '../../actions/graphql/categoryGQLActions';
 import EventNotFound from '../../components/EventNotFound';
-
 import mapListToComponent from '../../utils/mapListToComponent';
 
 /**
@@ -154,7 +154,11 @@ class EventsPage extends React.Component {
   }
 
   render() {
-    const { categoryList, hasNextPage } = this.state;
+    const {
+      categoryList,
+      hasNextPage,
+    } = this.state;
+    const { createEventBtn } = this.props;
     const catList = Array.isArray(categoryList) ? categoryList.map(item => ({
       id: item.node.id,
       title: item.node.name,
@@ -173,10 +177,13 @@ class EventsPage extends React.Component {
             Load more
           </button>
         </div>
+        {createEventBtn()}
       </div>
     );
   }
 }
+
+EventsPage.propTypes = { createEventBtn: PropTypes.func.isRequired };
 
 const mapStateToProps = state => ({
   events: state.events,

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -10,6 +10,7 @@ import { getEventsList, createEvent } from '../../actions/graphql/eventGQLAction
 import { getCategoryList } from '../../actions/graphql/categoryGQLActions';
 import EventNotFound from '../../components/EventNotFound';
 import mapListToComponent from '../../utils/mapListToComponent';
+import { ModalContextCreator } from '../../components/Modals/ModalContext';
 
 /**
  * @description  contains events dashboard page
@@ -47,7 +48,9 @@ class EventsPage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const {
-      events: { eventList, pageInfo: { hasNextPage } }, socialClubs,
+      events: {
+        eventList, pageInfo: { hasNextPage },
+      }, socialClubs,
     } = nextProps;
     const eventLength = eventList.length;
     const lastEventItemCursor = eventLength ? eventList[eventLength - 1].cursor : '';
@@ -153,12 +156,50 @@ class EventsPage extends React.Component {
     return <EventNotFound statusMessage="404" mainMessage="Events not found" />;
   }
 
+  /**
+  * @description It renders the create event FAB button
+  *
+   * @memberof EventsPage
+   */
+  renderCreateEventButton = () => (
+    <ModalContextCreator.Consumer>
+      {
+        ({
+          activeModal,
+          openModal,
+        }) => {
+          // TODO: This should be removed, duplicate naming
+          const {
+            categories, createEvent, uploadImage,
+          } = this.props;
+          if (activeModal) return null;
+          return (
+            <button
+              type="button"
+              onClick={() => openModal('CREATE_EVENT', {
+                modalHeadline: 'create event',
+                formMode: 'create',
+                formId: 'event-form',
+                categories,
+                createEvent,
+                uploadImage,
+                updateEvent: () => '',
+              })}
+              className="create-event-btn"
+            >
+              <span className="create-event-btn__icon">+</span>
+            </button>
+          );
+        }
+      }
+    </ModalContextCreator.Consumer>
+  );
+
   render() {
     const {
       categoryList,
       hasNextPage,
     } = this.state;
-    const { createEventBtn } = this.props;
     const catList = Array.isArray(categoryList) ? categoryList.map(item => ({
       id: item.node.id,
       title: item.node.name,
@@ -177,13 +218,15 @@ class EventsPage extends React.Component {
             Load more
           </button>
         </div>
-        {createEventBtn()}
+        {this.renderCreateEventButton()}
       </div>
     );
   }
 }
 
-EventsPage.propTypes = { createEventBtn: PropTypes.func.isRequired };
+EventsPage.defaultProps = { categories: [] };
+
+EventsPage.propTypes = { categories: PropTypes.arrayOf(PropTypes.shape({})) };
 
 const mapStateToProps = state => ({
   events: state.events,


### PR DESCRIPTION
#### What Does This PR Do?
- Fixes the display of the New Event FAB on the single event details page by making it not visible

#### Description Of Task To Be Completed
- Pass the renderCreateEventButton(categories) method as props on the dashboard page
- call the method on the events page only

#### Any Background Context You Want To Provide?
- Current Behavior
When a user clicks to view the details of an event, the floating action button for creating new events is still visible. This button is appearing out of context and not part of the original mockup

- Desired Behavior
Floating action button should not be visible

#### How can this be manually tested?
- Ensure docker is installed locally on the machine
- Ensure the environment variables in .env.sample are added in .env file in the root directory
- To build and spin up the docker containers, run make build
- To spin up the containers at a different time after building, `run make start`
- Click on any event card on the dashboard to view details of the event, you will notice the new event FAB is not visible

#### What are the relevant pivotal tracker stories?
- [#165210835](https://www.pivotaltracker.com/story/show/165210835)

#### Screenshot(s)
<img width="1440" alt="Screenshot 2019-04-14 at 9 32 11 PM" src="https://user-images.githubusercontent.com/30410066/56098853-fb284280-5efc-11e9-95a0-e963f593d9ba.png">

<img width="1440" alt="Screenshot 2019-04-14 at 9 31 49 PM" src="https://user-images.githubusercontent.com/30410066/56098845-eba8f980-5efc-11e9-8f37-bfa10ce676b7.png">
