### PR TITLE
#165211253 Add fix to remove the ability of a user to RSVP for past event 

### DIFF
--- a/client/assets/pages/_event_details-page.scss
+++ b/client/assets/pages/_event_details-page.scss
@@ -57,18 +57,58 @@
     font-size: rem(20px);
     font-style: normal;
     font-weight: lighter;
-    padding: 0 0 0 rem(26px);
-    margin-top: rem(-15px);
+    margin: 0 0 0 rem(26px);
     color: #797979;
   }
   &__rsvp_button{
-    margin: 0 0 0 rem(26px);
+    margin: rem(14px) 0 0 rem(26px);
     background-color: #3359DB;
     font-size: 1.25em;
     color: white;
     width: rem(147px);
     height: rem(41px);
+    &:disabled {
+      background-color: #ccc;
+      cursor: not-allowed;
+    }
   }
+  [tooltip] {
+    margin: 20px;
+    position: relative;
+  }
+  [tooltip]::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    margin-left: 2px;
+    transform: translateY(-50%) rotate(90deg);
+    border-color: rgba(0,0,0,0.7) transparent transparent     transparent;
+    border-style: solid;
+    z-index: 100;
+    opacity: 0;
+  }
+  [tooltip]::after {
+    content: attr(tooltip);
+    text-align: center;
+    background: rgba(0,0,0,0.7);
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    margin-left: 8px;
+    transform: translateX(0) translateY(-50%);
+    color: #fff;
+    padding: 4px 4px;
+    font-size: 12px;
+    min-width: 120px;
+    border-radius: 5px;
+    pointer-events: none;
+    z-index:99;
+    opacity:0;
+  }
+  [tooltip]:hover::after,[tooltip]:hover::before {
+    opacity:1
+ }
   &__location_time h5 {
     font-size: 1.25rem;
     font-style: normal;

--- a/client/reducers/eventReducers.js
+++ b/client/reducers/eventReducers.js
@@ -97,7 +97,20 @@ export const eventReducer = (state = initialState.event, action) => {
   switch (action.type) {
     case GET_EVENT: {
       const { event } = action.payload.data;
-      return event || {};
+      return {
+        ...state, event,
+      };
+    }
+    case ATTEND_EVENT: {
+      const { attendEvent: { newAttendance } } = action.payload;
+      return {
+        ...state, newAttendance,
+      };
+    }
+    case UNATTEND_EVENT: {
+      return {
+        ...state, newAttendance: undefined,
+      };
     }
     default:
       return state;
@@ -114,27 +127,6 @@ export const subscribedEvents = (state = initialState.subscribedEvents, action) 
   switch (action.type) {
     case SUBSCRIBED_EVENTS:
       return Object.assign({}, state, { subscribedEvents: action.payload.subscribedEvents });
-
-    case ATTEND_EVENT:
-      if (state.subscribedEvents !== undefined) {
-        const { subscribedEvents } = state;
-        const { payload } = action;
-        const eventCount =  subscribedEvents.filter(event => (event.id === payload.attendEvent.newAttendance.id)).length;
-        if (eventCount < 1) {
-          subscribedEvents.push(action.payload.attendEvent.newAttendance);
-          return { ...state, subscribedEvents };
-        }
-        return state;
-      }
-      return { ...state, subscribedEvents: [action.payload.attendEvent.newAttendance] };
-      
-
-    case UNATTEND_EVENT:
-      return Object.assign({}, state, {
-        subscribedEvents: state.subscribedEvents.filter(
-          item => item.event.id !== action.payload.unattendEvent.unsubscribedEvent.event.id
-        ),
-      });
 
     case SIGN_OUT:
       return Object.assign({}, state, { subscribedEvents: initialState.subscribedEvents });


### PR DESCRIPTION
#### What Does This PR Do?

- Prevents a user from being able to RSVP for an event whose start time has passed

#### Description Of Task To Be Completed

- [x] Change RSVP button text from "RSVP" to "Attend"
- [x] When the start date is and the end date is before the current date, "Attend" button should be replaced with a text informing the user that the event has commenced
- [x] When end date is past current date, "Attend" button should be replaced with a text informing the user that the event is a past event
- [x] When a user has already RSVP for an event, the "Attend" button should be disabled

#### Any Background Context You Want To Provide?

- N/A

#### How can this be manually tested?

- Pull & Checkout to this branch
- Start the application
- View an existing event whose start time has passed and notice the changes in [description of task to be completed](#description-of-task-to-be-completed) 

#### What are the relevant pivotal tracker stories?

[#165211253](https://www.pivotaltracker.com/story/show/165211253)

#### Screenshot(s)

<img width="1434" alt="Screen Shot 2019-04-24 at 7 41 08 PM" src="https://user-images.githubusercontent.com/9039613/56685128-1ba88780-66c9-11e9-8280-35b771873c82.png">

<img width="1440" alt="Screen Shot 2019-04-24 at 7 43 54 PM" src="https://user-images.githubusercontent.com/9039613/56685259-6fb36c00-66c9-11e9-8955-27ced6c696fd.png">
