### PR TITLE
#165211457 Fix events details page unnecessary reload

### DIFF
--- a/client/components/cards/EventCard.jsx
+++ b/client/components/cards/EventCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import formatDate from '../../utils/formatDate';
 
@@ -10,7 +11,7 @@ const EventCard = (props) => {
   } = props;
 
   return (
-    <a className="event-link" href={`/events/${id}`}>
+    <Link className="event-link" to={`/events/${id}`}>
       <div className="event-card">
         <img src={featuredImage || '/assets/img/img_group_selfie.jpg'} alt={title} className="event-card__picture" />
         <div className="event-card__caption-group">
@@ -19,7 +20,7 @@ const EventCard = (props) => {
           <p className="event-card__caption event-card__caption--tags">{`#${socialEvent.name}` || '#swimming #meetup'}</p>
         </div>
       </div>
-    </a>
+    </Link>
 
   );
 };


### PR DESCRIPTION
#### What Does This PR Do?

- Fixes an unnecessary reload of the web app that happens when a user tries to view the details of an event

#### Description Of Task To Be Completed

- [x] Wrap event card with router link component instead of anchor element

#### Any Background Context You Want To Provide?
*Current Behaviour on Develop Branch*

When a user tries to view the details of an event, the app is reloaded and state is lost

#### How can this be manually tested?
- Setup the project with Docker as outlined in the README
- Run `make build` and then `make start`
- Visit `localhost:9000`  in a browser
- Login and try to view the details of an event on the dashboard
- The page should not reload

#### What are the relevant pivotal tracker stories?
[#165211457](https://www.pivotaltracker.com/story/show/165211457)

#### Screenshot(s)
 - N/A