### PR TITLE
#165380956 fix slack notification

### DIFF
--- a/server/graphql_schemas/event/schema.py
+++ b/server/graphql_schemas/event/schema.py
@@ -113,8 +113,8 @@ class CreateEvent(relay.ClientIDMutation):
                        f"group \n Title: {input.get('title')} \n"
                        f"Description: {input.get('description')} \n "
                        f"Venue: {input.get('venue')} \n"
-                       f"Date: {input.get('date')} \n"
-                       f"Time: {input.get('time')}")
+                       f"Date: {input.get('start_date').date()} \n"
+                       f"Time: {input.get('start_date').time()}")
             slack_id_not_in_db = []
             all_users_attendance = []
             for instance in category_followers:


### PR DESCRIPTION
#### What Does This PR Do?
 Notify a subscribed user once an event is created
#### Description Of Task To Be Completed
When an event is created in a category that a Slack user is subscribed to, the Slack user should be notified via Slack
#### Any Background Context You Want To Provide?
The functionality currently doesn't work .i.e. slack alert arent sent to subscribed users
#### How can this be manually tested?
Subscribe a registered user to a given category. That information should be stored in the interest table.
Then create an event with that given category. A slack message will be sent to a user to the Andela test workplace. 
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/165380956
#### Screenshot(s)

![Screen Shot 2019-04-23 at 6 26 44 PM](https://user-images.githubusercontent.com/29740871/56594376-6062ee80-65f5-11e9-8f6a-97eae19ca503.png)

