### PR TITLE
#165380511: Enable Multiple Interests for Users

### DIFF
--- a/server/graphql_schemas/tests/interest/test_mutations.py
+++ b/server/graphql_schemas/tests/interest/test_mutations.py
@@ -14,9 +14,9 @@ class InterestTestCase(BaseEventTestCase):
         query = f'''
         mutation{{
             joinCategory(input:{{
-                categoryId:"{to_global_id("CategoryNode", self.category2.id)}",
+                categories:"{[to_global_id("CategoryNode", self.category2.id)]}",
             }}){{
-                joinedCategory{{
+                joinedCategoryList{{
                 id
                 followerCategory{{
                     id
@@ -58,9 +58,9 @@ class InterestTestCase(BaseEventTestCase):
         query = f'''
         mutation{{
             joinCategory(input:{{
-                categoryId:"{to_global_id("CategoryNode", self.category2.id)}",
+                categories:"{[to_global_id("CategoryNode", self.category2.id)]}",
             }}){{
-                joinedCategory{{
+                joinedCategoryList{{
                 id
                 followerCategory{{
                     id


### PR DESCRIPTION
#### What Does This PR Do?
This PR delivers functionality for users to be able to select multiple interests.

#### Description Of Task To Be Completed
1. Change method on the graphQl schema to allow multiple interests

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
- git pull this branch
- start the server 
- Enter GraphQl mutation to `JoinCategory` and input an array of ` categoryIds` for the categories field

#### What are the relevant pivotal tracker stories?
[#165380511](https://www.pivotaltracker.com/story/show/165380511)

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/29812424/56740959-dab47f80-6769-11e9-8643-a93c3715d119.png)
