### PR TITLE
#165767221 Fix event form validation

### DIFF
--- a/client/components/Forms/EventForm.js
+++ b/client/components/Forms/EventForm.js
@@ -161,7 +161,7 @@ class EventForm extends Component {
     const errorFields = Object.keys(errors);
 
     errorFields.forEach((field) => {
-      if ((field !== 'time' && field !== 'imgUrl') && formData[field].trim().length === 0) {
+      if (typeof formData[field] === 'string' && !formData[field].trim().length) {
         errors[field].hasError = true;
       } else {
         errors[field].hasError = false;


### PR DESCRIPTION
#### What Does This PR Do?
- Fixes event form validation bug

#### Description Of Task To Be Completed
- Enforce trim validation for only text fields

#### Any Background Context You Want To Provide?
- User is unable to create events due to broken validation which runs before form is submitted

#### How can this be manually tested?
- Start the app and login
- Try to create an event
- If any of the text fields are empty or the input is just whitespace, you should get appropriate validation errors
- Else, the form should submit and the new event should be visible on the page

#### What are the relevant pivotal tracker stories?
[#165767221](https://www.pivotaltracker.com/story/show/165767221)

#### Screenshot(s)
