### PR TITLE
#165717991 Redirect an authenticated user to the '/interests' page

### DIFF
--- a/client/assets/components/navbar.scss
+++ b/client/assets/components/navbar.scss
@@ -110,8 +110,9 @@
       box-shadow: rem(-1px) rem(6px) rem(6px) $grey;
       border: 0;
       border-radius: 0;
-      height: 9.125rem;
-      width: 10rem;
+      height: 13.187rem;
+      width: 10.5rem;
+
       li {
         @include centered-flex;
         height: 2.5rem;
@@ -120,7 +121,14 @@
         &:first-child:after {
           content: '';
           position: absolute;
-          bottom: 50%;
+          bottom: 33%;
+          width: 80%;
+          border-bottom: rem(1px) solid $grey;
+        }
+        &:last-child:before {
+          content: '';
+          position: absolute;
+          bottom: 66%;
           width: 80%;
           border-bottom: rem(1px) solid $grey;
         }

--- a/client/components/common/SideNav.js
+++ b/client/components/common/SideNav.js
@@ -19,7 +19,7 @@ const SideNav = ({ signOut }) => (
         <Link to="/notifications" onClick={closeNav}>Notifications</Link>
       </div>
       <div>
-        <Link to="/interests" onClick={closeNav}>Interests</Link>
+        <Link to="/interests" onClick={closeNav}>My Interests</Link>
       </div>
       <div>
         <Link to="/settings" onClick={closeNav}>Settings</Link>

--- a/client/components/common/SideNav.js
+++ b/client/components/common/SideNav.js
@@ -19,6 +19,9 @@ const SideNav = ({ signOut }) => (
         <Link to="/notifications" onClick={closeNav}>Notifications</Link>
       </div>
       <div>
+        <Link to="/interests" onClick={closeNav}>Interests</Link>
+      </div>
+      <div>
         <Link to="/settings" onClick={closeNav}>Settings</Link>
       </div>
       <div>

--- a/client/components/common/UserProfile.js
+++ b/client/components/common/UserProfile.js
@@ -22,6 +22,9 @@ const UserProfile = ({
       <span className="caret nav-profile__dropdown-icon" />
     </button>
     <ul className="dropdown-menu nav-profile__list-menus">
+    <li>
+    <Link to="/interests">Interests</Link>
+    </li>
       <li>
         <Link to="/settings">Settings</Link>
       </li>

--- a/client/components/common/UserProfile.js
+++ b/client/components/common/UserProfile.js
@@ -23,7 +23,7 @@ const UserProfile = ({
     </button>
     <ul className="dropdown-menu nav-profile__list-menus">
     <li>
-    <Link to="/interests">Interests</Link>
+    <Link to="/interests">My Interests</Link>
     </li>
       <li>
         <Link to="/settings">Settings</Link>


### PR DESCRIPTION
#### What Does This PR Do?

- Redirect an authenticated user to the '/interests' page

#### Description Of Task To Be Completed

- Add /interests page
- Add Interests to the profile drop-down menu
- Add styling to the drop-down to accommodate the new item added to the list

#### Any Background Context You Want To Provide?
- N/A

#### How can this be manually tested?

- Start the app and log in
- Navigate to the profile menu on the top-right end of the browser and click
- You will see a drop-down menu with `Interests` as one of the items
- Click on `interests` to be redirected to the /interests page where you can update your interests

#### What are the relevant Github issues?
[#165717991](https://www.pivotaltracker.com/story/show/165717991)

#### Screenshot(s)
<img width="1440" alt="Screenshot 2019-05-02 at 4 51 15 PM" src="https://user-images.githubusercontent.com/30410066/57088676-b4a75600-6cfa-11e9-8cf3-9652d7a60942.png">
