### PR TITLE
# 165717871: User should be able to view more details about event from Slack

### DIFF
--- a/server/api/slack.py
+++ b/server/api/slack.py
@@ -52,7 +52,7 @@ def notify_user(message, slack_id):
     return slack_client.api_call(
         "chat.postMessage",
         channel=slack_id,
-        text=message,
+        blocks=message,
         as_user=True,
         reply_broadcast=True,
     )
@@ -68,3 +68,29 @@ def get_slack_user_timezone(email):
         if member.get('profile').get('email') == email:
             return member.get('tz')
     return ''
+
+
+def new_event_message(message, event_url):
+    """
+    Return slack message to send when new event is created
+    """
+    return [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": message
+            }
+    }, {
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "View Details",
+                    "emoji": True
+                },
+                "url": event_url
+            }
+        ]
+    }]


### PR DESCRIPTION
#### What Does This PR Do?
- adds a button for view event details on slack

#### Description Of Task To Be Completed
As a user subscribed to a category, when I get Slack notifications about events happening in the category, I should be able to see a "View details" button such that when I click on the button, I am redirected to the event page in a browser.

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
- create an event and when you receive a notification
- you should see a button `View Details`.
- when you click on it it should redirect you to the browser showing details about the event.

#### What are the relevant github issues?
N/A

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/28973383/57215274-0995e580-6ff5-11e9-9cc5-1215c48ada76.png)
