### PR TITLE
#165717628 User should be able to attend event from slack

### DIFF
--- a/client/pages/Event/EventDetailsPage.jsx
+++ b/client/pages/Event/EventDetailsPage.jsx
@@ -124,7 +124,7 @@ class EventDetailsPage extends React.Component {
                 {' '}
                 Attend &#10004;
             </button>
-            )}
+          )}
         </div>
         <div className="event-details__section">
           <div className="event-details__location_time event-details__section">

--- a/server/api/slack.py
+++ b/server/api/slack.py
@@ -45,7 +45,7 @@ def notify_channel(message):
     )
 
 
-def notify_user(message, slack_id):
+def notify_user(message, slack_id, **kwargs):
     """
     Notify the user with the given id with the message
         :param message:
@@ -57,6 +57,7 @@ def notify_user(message, slack_id):
         blocks=message,
         as_user=True,
         reply_broadcast=True,
+        **kwargs,
     )
 
 
@@ -72,7 +73,7 @@ def get_slack_user_timezone(email):
     return ''
 
 
-def new_event_message(message, event_url):
+def new_event_message(message, event_url, event_id):
     """
     Return slack message to send when new event is created
     """
@@ -83,17 +84,45 @@ def new_event_message(message, event_url):
             "text": message
         }
     }, {
-        "type":
-        "actions",
-        "elements": [{
-            "type": "button",
-            "text": {
-                "type": "plain_text",
-                "text": "View Details",
-                "emoji": True
+        "type": "actions",
+        "block_id": "event_actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Attend",
+                },
+                "action_id": "attend_event",
+                "style": "primary",
+                "value": event_id
             },
-            "url": event_url
-        }]
+            {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "View Details",
+                    "emoji": True
+                },
+                "url": event_url
+            }
+        ]
+    }]
+
+
+def generate_simple_message(text):
+    """
+    Generate message block
+    :rtype: list
+    :param text:
+    :return: list of dictionary containing the slack markdown message structure
+    """
+    return [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": text
+        }
     }]
 
 
@@ -110,3 +139,4 @@ def get_slack_user_token(code):
         code=code)
 
     return response
+

--- a/server/api/urls.py
+++ b/server/api/urls.py
@@ -50,6 +50,10 @@ urlpatterns = [
 
     url(r'^oauthcallback/?$', views.OauthCallback.as_view(),
         name='oauth_callback'),
+
+    url(r'^slack/actions/?$', views.SlackActionsCallback.as_view(),
+        name='slack_action_callback'),
+        
     url(r'^slack/authorize/?$', views.LaunchSlackAuthorization.as_view(),
         name="authorizeslack"),
 ]

--- a/server/api/utils/event_helpers.py
+++ b/server/api/utils/event_helpers.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from pytz import timezone
+from dateutil.parser import parse
+
+from api.models import Attend
+
+
+def is_not_past_event(event):
+    """
+    This function checks if an event is not a past event
+    :param event:
+    :return bool:
+    """
+    event_start_date = parse(event.start_date)
+    event_tz = timezone(event.timezone)
+    if event_start_date.tzinfo is None:
+        event_start_date = event_start_date.replace(tzinfo=event_tz)
+    today = datetime.now(event_tz)
+    return today < event_start_date
+
+
+def save_user_attendance(event, user_profile, status):
+    return Attend.objects.get_or_create(
+        user=user_profile, event=event, status="attending")

--- a/server/graphql_schemas/event/schema.py
+++ b/server/graphql_schemas/event/schema.py
@@ -115,13 +115,13 @@ class CreateEvent(relay.ClientIDMutation):
                 follower_category_id=category.id)
             event_id = to_global_id(EventNode._meta.name, new_event.id)
             event_url = f"{dotenv.get('FRONTEND_BASE_URL')}/{event_id}"
-            message = (f"*A new event has been created in {category.name} "
-                       f"group* \n *Title:* {input.get('title')} \n"
-                       f"*Description:* {input.get('description')} \n "
-                       f"*Venue:* {input.get('venue')} \n"
-                       f"*Date:* {input.get('start_date').date()} \n"
-                       f"*Time:* {input.get('start_date').time()}")
-            blocks = new_event_message(message, event_url)
+            message = (f"*A new event has been created in `{category.name}` group*\n"
+                       f"> *Title:* {input.get('title')}\n"
+                       f"> *Description:* {input.get('description')}\n"
+                       f"> *Venue:* {input.get('venue')}\n"
+                       f"> *Date:*  {input.get('start_date').date()}\n"
+                       f"> *Time:*  {input.get('start_date').time()}")
+            blocks = new_event_message(message, event_url, str(new_event.id))
             slack_id_not_in_db = []
             all_users_attendance = []
             for instance in category_followers:
@@ -130,7 +130,7 @@ class CreateEvent(relay.ClientIDMutation):
                 all_users_attendance.append(new_attendance)
                 if instance.follower.slack_id:
                     slack_response = notify_user(
-                        blocks, instance.follower.slack_id)
+                        blocks, instance.follower.slack_id, text="New upcoming event from Andela socials")
                     if not slack_response['ok']:
                         logging.warn(slack_response)
                 else:


### PR DESCRIPTION
#### What Does This PR Do?

- This PR gives the user the ability to accept an event from slack
#### Description Of Task To Be Completed

- [x] The slack message sent to a user when an event is created in their category of interest should include an "Attend" button
- [x] When a user clicks the "Attend" button, they should get a response message indicating whether the action was successful or not
#### Any Background Context You Want To Provide?
 - None
#### How can this be manually tested?
- Enable interactivity in the slack app and add a Request URL to the slack app pointing to the endpoint '/api/v1/slack/actions/'
- You might need to add a secure (https) URL as the Request URL. You can use ngrok server to tunnel to localhost then use the secure https URL if testing via localhost
- Follow an interest, you can manually insert this in the `api_interests` table in the db
- Create an event from the client site in a category whose id is the same as that of the interest you followed
- You should get a notification via slack that a new event has been created
- Click the attend button and you should get another message stating that - "You are now attending the event"
#### What are the relevant pivotal tracker stories?
[#165717628](https://www.pivotaltracker.com/story/show/165717628)
#### Screenshot(s)
<img width="716" alt="Screen Shot 2019-05-09 at 3 57 21 PM" src="https://user-images.githubusercontent.com/9039613/57463765-5850b300-7273-11e9-96eb-5769c50f9310.png">
