### PR TITLE
#165718497: Get all slack public channels

### DIFF
--- a/server/api/slack.py
+++ b/server/api/slack.py
@@ -140,3 +140,18 @@ def get_slack_user_token(code):
 
     return response
 
+    
+
+def get_slack_channels_list(limit=100):
+    """
+    Helper Function to get list of all slcak conversations
+    """
+    channels_list = slack_client.api_call(
+        "conversations.list",
+        exclude_archived=True,
+        limit=limit
+    )
+    if channels_list.get('ok'):
+        # retrieve all slack channels
+        return channels_list
+    return ''

--- a/server/graphql_schemas/event/schema.py
+++ b/server/graphql_schemas/event/schema.py
@@ -25,7 +25,7 @@ from graphql_schemas.scalars import NonEmptyString
 from graphql_schemas.utils.hasher import Hasher
 from api.models import Event, Category, AndelaUserProfile, \
     Interest, Attend
-from api.slack import get_slack_id, notify_user, new_event_message
+from api.slack import get_slack_id, notify_user, new_event_message, get_slack_channels_list
 
 from api.utils.backgroundTaskWorker import BackgroundTaskWorker
 
@@ -318,10 +318,49 @@ class ValidateEventInvite(relay.ClientIDMutation):
                 message=str(err)
             )
 
+class ChannelList(graphene.ObjectType):
+    id = graphene.ID()
+    name = graphene.String()
+    is_channel = graphene.String()
+    created = graphene.Int()
+    creator = graphene.String()
+    is_archived = graphene.Boolean()
+    is_general = graphene.Boolean()
+    name_normalized = graphene.String()
+    is_shared = graphene.Boolean()
+    is_org_shared = graphene.Boolean()
+    is_member = graphene.Boolean()
+    is_private = graphene.Boolean()
+    unlinked = graphene.String()
+    is_im = graphene.Boolean()
+    is_mpim = graphene.Boolean()
+    is_group = graphene.Boolean()
+    members = graphene.List(graphene.String)
+    previous_names = graphene.List(graphene.String)
+    num_members = graphene.Int()
+    parent_conversation = graphene.String()
+    is_pending_ext_shared = graphene.Boolean()
+    pending_shared = graphene.List(graphene.Boolean)
+    is_ext_shared = graphene.Boolean()
+
+
+class ResponseMetadata(graphene.ObjectType):
+    next_cursor = graphene.String()
+
+
+class SlackChannelsList(graphene.ObjectType):
+    ok = graphene.Boolean()
+    channels = graphene.List(ChannelList)
+    response_metadata = graphene.Field(ResponseMetadata)
+
+    class Meta:
+        interfaces = (relay.Node,)
 
 class EventQuery(object):
     event = relay.Node.Field(EventNode)
     events_list = DjangoFilterConnectionField(EventNode)
+    slack_channels_list = graphene.Field(SlackChannelsList)
+
 
     def resolve_event(self, info, **kwargs):
         id = kwargs.get('id')
@@ -335,6 +374,18 @@ class EventQuery(object):
 
     def resolve_events_list(self, info, **kwargs):
         return Event.objects.exclude(active=False)
+
+    def resolve_slack_channels_list(self, info, **kwargs):
+        channels = []
+        slack_list = get_slack_channels_list()
+        responseMetadata = ResponseMetadata(**slack_list.get('response_metadata'))
+        for items in slack_list.get('channels'):
+            selection = ['topic', 'purpose', 'shared_team_ids']
+            filtered_channel = dict(filter(lambda x: x[0] not in selection, items.items()))
+            channel = ChannelList(**filtered_channel)
+            channels.append(channel)
+        return SlackChannelsList(
+            ok=slack_list.get('ok'),channels=channels,response_metadata=responseMetadata)
 
 
 class EventMutation(ObjectType):


### PR DESCRIPTION
#### What Does This PR Do?
This PR delivers the graphQL query implementation to get all slack channels

#### Description Of Task To Be Completed
1. Write a method to get all public slack channels
2. Create a GraphQL query to call the method to get all public slack channels

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
- git pull this branch
- open the `graphiQL` or any `graphQL` playground and test the `slackChannelsList` Query

#### What are the relevant pivotal tracker stories?
[#165718497](https://www.pivotaltracker.com/story/show/165718497)

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/29812424/57452856-bde57500-725c-11e9-8272-09c9391a9f27.png)

![image](https://user-images.githubusercontent.com/29812424/57452817-a60df100-725c-11e9-840f-9041542ff989.png)
