### PR TITLE
#165717529 Add header/subheader to give context to users

### DIFF
--- a/client/assets/pages/interests.scss
+++ b/client/assets/pages/interests.scss
@@ -15,22 +15,31 @@
 
 .interests-page {
   padding: 2em 5em 7em;
+  text-align: center;
   @include tablet {
-    padding: 2em 2em 7em;
+    padding: 2em 1.5em 7em;
+  }
+  &__header {
+    margin-bottom: 20px;
+    color: #555;
+  }
+  &__subheader {
+    margin-bottom: 35px;
+    color: gray;
   }
   .interests {
     display: grid;
-    grid-template-columns: repeat(5,1fr);
+    grid-template-columns: repeat(6,1fr);
     justify-items: center;
     @include tablet {
-      grid-template-columns: repeat(3,1fr);
+      grid-template-columns: repeat(4,1fr);
     }
     @include mobile {
       grid-template-columns: repeat(2,1fr);
     }
     &-card {
-      padding: 1em 1em 1em 1.5em;
-      min-width: 12.5em;
+      padding: .7em .7em .7em 1.2em;
+      min-width: 10em;
       cursor: pointer;
       color: #C4C4C4;
       border: 1px solid #C4C4C4;
@@ -43,11 +52,12 @@
       p {
         text-transform: capitalize;
         margin-right: .4em;
+        font-size: 18px;
       }
       &__icon-close {
         @include centered-flex;
-        width: 2.2em;
-        height: 2.2em;
+        width: 2em;
+        height: 2em;
         border-radius: 50%;
         border: 1px solid #C4C4C4;
         margin-left: auto;
@@ -58,15 +68,12 @@
           }        
         }
         .interest-icon {
-          font-size: 13px;
+          font-size: 12px;
         }
       }
       &__icon-check {
-        font-size: 22px;
+        font-size: 20px;
         margin-left: auto;
-        .interest-icon {
-          font-size: 13px;
-        }
       }
       p {
         font-size: 20px;

--- a/client/pages/Interests/index.jsx
+++ b/client/pages/Interests/index.jsx
@@ -38,6 +38,8 @@ class Interests extends React.Component {
 
     return (
       <div className="interests-page">
+        <h2 className="interests-page__header">Choose activities that interest you.</h2>
+        <p className="interests-page__subheader">Select and deselect interests below.</p>
         <div className="interests">
           {
             interests.map(({name, isSelected}, index) => {


### PR DESCRIPTION
#### What Does This PR Do?
This PR adds UX fixes to Interests Page

#### Description Of Task To Be Completed
  - add header/subheader titles to interests
  - make selection cards smaller
  - increase card numbers per rows on breakpoints

#### Any Background Context You Want To Provide?
None

#### How can this be manually tested?
- navigate to Interests page to observe UI/UX changes described above

#### What are the relevant github issues?
None

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/26779819/57531585-c5c31900-7331-11e9-81eb-2c6938905d21.png)