### PR TITLE
ft(share-event-165718129) User should be able to share an event to specified Slack channel

### DIFF
--- a/client/Graphql/Queries/SlackChannelsListGQL.js
+++ b/client/Graphql/Queries/SlackChannelsListGQL.js
@@ -1,0 +1,20 @@
+import gql from 'graphql-tag';
+
+const SLACK_CHANNELS_LIST_GQL = () => ({
+  query: gql`
+    query {
+      slackChannelsList {
+        ok
+        channels {
+          id,
+          name,
+          creator,
+          created,
+          isGroup
+        }
+      }
+    }
+  `
+});
+
+export default SLACK_CHANNELS_LIST_GQL;

--- a/client/actions/constants.js
+++ b/client/actions/constants.js
@@ -39,6 +39,9 @@ export const GET_EVENT_ATTENDENCE = 'GET_EVENT_ATTENDENCE';
 export const INTERESTS = 'INTERESTS';
 export const INTEREST = 'INTEREST';
 
+// Constants specific to slack channels
+export const CHANNELS = 'CHANNELS';
+
 // Constants OAUTH
 export const OAUTH = 'OAUTH';
 

--- a/client/actions/graphql/slackChannelsGQLActions.js
+++ b/client/actions/graphql/slackChannelsGQLActions.js
@@ -1,0 +1,15 @@
+import SLACK_CHANNELS_LIST_GQL from '../../Graphql/Queries/SlackChannelsListGQL';
+
+import { CHANNELS } from '../constants';
+
+import { handleError } from '../../utils/errorHandler';
+import Client from '../../client';
+
+export const getSlackChannelsList = () => dispatch => Client.query(
+    SLACK_CHANNELS_LIST_GQL()
+  ).then(data => dispatch({
+    type: CHANNELS,
+    payload: data.data,
+    error: false
+  }))
+  .catch(error => handleError(error, dispatch));

--- a/client/assets/pages/_event_details-page.scss
+++ b/client/assets/pages/_event_details-page.scss
@@ -100,7 +100,7 @@
   .menu {
     position: absolute;
     width: rem(180px);
-    margin: 0 0 0 rem(180px);
+    margin: 0 0 0 rem(188px);
     top: 180px;
     box-shadow: 1px 1px 15px rgba(0, 0, 0, 0.1);
 

--- a/client/pages/Event/EventDetailsPage.jsx
+++ b/client/pages/Event/EventDetailsPage.jsx
@@ -6,6 +6,7 @@ import moment from 'moment-timezone';
 
 import { getEvent, deactivateEvent } from '../../actions/graphql/eventGQLActions';
 import { attendEvent } from '../../actions/graphql/attendGQLActions';
+import { getSlackChannelsList } from '../../actions/graphql/slackChannelsGQLActions';
 import NotFound from '../../components/common/NotFound';
 import slackChannels from '../../fixtures/slackChannels';
 import SlackIcon from '../../assets/icons/SlackIcon';
@@ -41,6 +42,7 @@ class EventDetailsPage extends React.Component {
    */
   componentDidMount() {
     this.loadEvent();
+    this.loadSlackChannels();
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -205,7 +207,7 @@ class EventDetailsPage extends React.Component {
     );
   };
 
-  renderSlackChannels = () => slackChannels.channels.map(channel => (
+  renderSlackChannels = () => this.props.slackChannels.map(channel => (
             <a
              href
              key={channel.id}>
@@ -222,6 +224,11 @@ class EventDetailsPage extends React.Component {
     const { match: { params: { eventId } } } = this.props;
     const { getEventAction } = this.props;
     getEventAction(eventId);
+  }
+
+  loadSlackChannels() {
+    const { getSlackChannelsList } = this.props;
+    getSlackChannelsList();
   }
 
   showSlackChannels = (evt) => {
@@ -336,6 +343,7 @@ class EventDetailsPage extends React.Component {
 EventDetailsPage.propTypes = {
   match: PropTypes.shape({ params: PropTypes.shape({ eventId: PropTypes.string }) }),
   getEventAction: PropTypes.func,
+  getSlackChannelsList: PropTypes.func,
   deactivateEventAction: PropTypes.func,
   attendEventAction: PropTypes.func,
   history: PropTypes.shape({ push: PropTypes.func.isRequired }),
@@ -371,6 +379,7 @@ EventDetailsPage.defaultProps = {
   attendEventAction: () => null,
   updateEvent: () => null,
   uploadImage: () => null,
+  getSlackChannelsList: () => null
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators(
@@ -378,6 +387,7 @@ const mapDispatchToProps = dispatch => bindActionCreators(
     getEventAction: getEvent,
     deactivateEventAction: deactivateEvent,
     attendEventAction: attendEvent,
+    getSlackChannelsList
   },
   dispatch
 );
@@ -385,6 +395,7 @@ const mapDispatchToProps = dispatch => bindActionCreators(
 const mapStateToProps = state => ({
   event: state.event.event,
   events: state.events,
+  slackChannels: state.slackChannels.channels
 });
 export default connect(
   mapStateToProps,

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -8,6 +8,7 @@ import {
   uploadImage,
 } from './eventReducers';
 import interests from './interestReducers';
+import slackChannels from './slackChannelsReducers';
 import url from './urlReducers';
 import userReducers from './userReducers';
 import { inviteValidation } from './inviteReducers';
@@ -27,6 +28,7 @@ const rootReducer = {
   url,
   oauth,
   invite: inviteValidation,
+  slackChannels
 };
 
 export default rootReducer;

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -14,4 +14,5 @@ export default {
   eventsSearchList: [],
   oauth: '',
   invite: {},
+  slackChannels: {}
 };

--- a/client/reducers/slackChannelsReducers.js
+++ b/client/reducers/slackChannelsReducers.js
@@ -1,0 +1,22 @@
+import initialState from './initialState';
+import {
+  CHANNELS
+} from '../actions/constants';
+
+/**
+ * Reducer for slackChannels
+ * @param {object} [state=initialState.slackChannels]
+ * @param {object} action
+ * @returns {array} new state of interests
+ */
+const slackChannels = (state = initialState.slackChannels, action) => {
+  switch (action.type) {
+    case CHANNELS:
+      return action.payload.slackChannelsList;
+
+    default:
+      return state;
+  }
+};
+
+export default slackChannels;


### PR DESCRIPTION
#### What Does This PR Do?
This PR adds a `share on slack` button  to the event details page and shows a dropdown with a list of available channels on slack

#### Description Of Task To Be Completed
- add a button to share on slack
- display a dropdown with a list of slack channels

#### Any Background Context You Want To Provide?
None
#### How can this be manually tested?
- Start the app
- Navigate to an event details page
- Click on the `Share to slack` button

#### What are the relevant pivotal tracker stories?
#165718129
#### Screenshot(s)
![image](https://user-images.githubusercontent.com/27571135/57666688-c17c5180-75f8-11e9-8d78-8434ea362de3.png)
