### PR TITLE
#165999709(feat): Add event to attendee's calendar

### DIFF
--- a/server/api/views.py
+++ b/server/api/views.py
@@ -18,6 +18,7 @@ from .models import Category, Interest, Event, Attend, AndelaUserProfile
 from .utils.oauth_helper import save_credentials
 
 from .setpagination import LimitOffsetpage
+from graphql_schemas.utils.helpers import add_event_to_calendar
 
 
 class LoginRequiredMixin(object):
@@ -146,6 +147,7 @@ class AttendSocialEventView(APIView):
             event=event
         )
         user_attendance.save()
+        add_event_to_calendar(request.cached_user, event)
 
         serializer = AttendanceSerializer(user_attendance)
         return Response(serializer.data)
@@ -270,12 +272,13 @@ class SlackActionsCallback(APIView):
                     else:
                         message = generate_simple_message(
                             '> You\'ve successfully registered for the event :tada:')
+                        add_event_to_calendar(andela_user_profile, event)
 
                 else:
                     message = generate_simple_message(
                         'Oops! The event you want to attend is a past event')
             except Event.DoesNotExist:
-                    message = generate_simple_message(
+                message = generate_simple_message(
                         'Oops! It seems this event has been removed.')
             except AndelaUserProfile.DoesNotExist:
                 message = generate_simple_message(

--- a/server/graphql_schemas/attend/schema.py
+++ b/server/graphql_schemas/attend/schema.py
@@ -8,6 +8,7 @@ from graphql import GraphQLError
 
 from api.models import Attend, Event, AndelaUserProfile
 from api.utils.event_helpers import is_not_past_event, save_user_attendance
+from graphql_schemas.utils.helpers import add_event_to_calendar
 
 
 class AttendNode(DjangoObjectType):
@@ -33,7 +34,7 @@ class AttendEvent(relay.ClientIDMutation):
         user = info.context.user
         andela_user_profile = AndelaUserProfile.objects.get(
             user_id=user.id)
-
+        add_event_to_calendar(andela_user_profile, event)
         if is_not_past_event(event):
             user_attendance, created = save_user_attendance(event, andela_user_profile, status)
         else:

--- a/server/graphql_schemas/utils/helpers.py
+++ b/server/graphql_schemas/utils/helpers.py
@@ -201,3 +201,17 @@ async def send_bulk_update_message(event_instance, message, notification_text):
                     message, slack_id, text=notification_text)
             elif not slack_response['ok']:
                 logging.warning(slack_response)
+
+
+def add_event_to_calendar(andela_user, event):
+    """
+        Adds an event to a user's calendar
+         :param andela_user:
+         :param event:
+    """
+    attendees = [{"email": attendee.user.user.email}
+                 for attendee in event.attendees]
+    calendar = build('calendar', 'v3', credentials=andela_user.credential)
+    event_details = build_event(event, attendees)
+    return calendar.events().insert(
+            calendarId='primary', body=event_details).execute()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -26,6 +26,7 @@ flake8==3.5.0
 google-api-core==1.4.0
 google-api-python-client==1.6.2
 google-auth==1.5.1
+google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.2.0
 google-cloud-core==0.28.1
 google-cloud-storage==1.11.0


### PR DESCRIPTION
#### What Does This PR Do?
- adds a method to add an event to a user's calendar
- calls the method when a user clicks attend to an event on slack
- calls the method on attendEvent mutation

#### Description Of Task To Be Completed
- As an event attendee, when I indicate to attend an event, the event should be added to my Google calendar.

#### Any Background Context You Want To Provide?
- remember to install from requirements.txt. 
- this added module is important for this feature to work`google-auth-httplib2==0.0.3`

#### How can this be manually tested?
- start the server
- create an event in the future and copy the global `event_id`
- on your database client in the table `api_andelauserprofile` temporarily change the `user_id` to point to the admin on the `auth_user` table. This for testing, remember to change it back
- run the mutation below from `localhost:8000/graphql`
- check your calendar for the added event
![image](https://user-images.githubusercontent.com/28973383/58030761-c6c12b00-7b27-11e9-9201-1d4ab20ac51f.png)


#### What are the relevant pivotal tracker stories?
[#165999709 Event should automatically be added to event attendee's calendar when they attend](https://www.pivotaltracker.com/story/show/165999709)

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/28973383/58030324-050a1a80-7b27-11e9-9238-f97791f5990d.png)
