### PR TITLE
#165977941 Add interests functionality

### DIFF
--- a/client/Graphql/Mutations/CreateInterestGQL.js
+++ b/client/Graphql/Mutations/CreateInterestGQL.js
@@ -1,0 +1,28 @@
+import gql from 'graphql-tag';
+
+const CREATE_INTEREST_GQL = (interestsId, clientMutationId = '') => ({
+  mutation: gql`
+   mutation($input: JoinCategoryInput!){
+    joinCategory(input: $input){
+      joinedCategoryList{
+        id
+        followerCategory{
+         createdAt
+         updatedAt
+         id
+         name
+      }
+    }
+    clientMutationId
+      }
+     
+   }`,
+  variables: {
+    input: {
+      categories: interestsId,
+      clientMutationId
+    }
+  },
+});
+
+export default CREATE_INTEREST_GQL;

--- a/client/Graphql/Mutations/DeactivateEventGQL.js
+++ b/client/Graphql/Mutations/DeactivateEventGQL.js
@@ -17,3 +17,4 @@ const DEACTIVATE_EVENT_GQL = (eventId, clientMutationId = '') => ({
 });
 
 export default DEACTIVATE_EVENT_GQL;
+

--- a/client/Graphql/Mutations/RemoveInterestGQL.js
+++ b/client/Graphql/Mutations/RemoveInterestGQL.js
@@ -1,0 +1,26 @@
+import gql from 'graphql-tag';
+
+const REMOVE_INTEREST_GQL = (interestsId, clientMutationId = '') => ({
+  mutation: gql`
+   mutation($input: UnJoinCategoryInput!){
+    unjoinCategory(input: $input){
+      unjoinedCategories{
+        id
+        followerCategory{
+         id
+         name
+      }
+    }
+    clientMutationId
+      }
+     
+   }`,
+  variables: {
+    input: {
+      categories: interestsId,
+      clientMutationId
+    }
+  },
+});
+
+export default REMOVE_INTEREST_GQL;

--- a/client/Graphql/Queries/InterestsListGQL.js
+++ b/client/Graphql/Queries/InterestsListGQL.js
@@ -2,18 +2,8 @@ import gql from 'graphql-tag';
 
 const INTERESTS_LIST_GQL = (before = '', after = '', first = 1, last = 1) => ({
   query: gql`
-    query(
-      $before: String,
-      $after: String,
-      $first: Int,
-      $last: Int
-    ){
-      interestsList(
-        before: $before
-        after: $after
-        first: $first
-        last: $last
-      ){
+    query{
+      interestsList{
         pageInfo{
           hasNextPage
           hasPreviousPage
@@ -26,6 +16,7 @@ const INTERESTS_LIST_GQL = (before = '', after = '', first = 1, last = 1) => ({
             updatedAt
             id
             followerCategory{
+              id
               name
               featuredImage
               description
@@ -34,13 +25,7 @@ const INTERESTS_LIST_GQL = (before = '', after = '', first = 1, last = 1) => ({
           cursor
         }
       }
-    }`,
-  variables: {
-    before,
-    after,
-    first,
-    last,
-  },
+    }`
 });
 
 export default INTERESTS_LIST_GQL;

--- a/client/Graphql/Queries/JoinedCategoriesGQL.js
+++ b/client/Graphql/Queries/JoinedCategoriesGQL.js
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+
+//To get all all the interests of a user
+const JOINED_CATEGORIES_GQL = () => ({
+  query: gql`
+    query{
+      joinedCategories{
+        createdAt
+        updatedAt
+        id
+        followerCategory{
+            id
+            name
+            featuredImage
+            description
+        }
+      }
+    }`,
+});
+
+export default JOINED_CATEGORIES_GQL;

--- a/client/actions/constants.js
+++ b/client/actions/constants.js
@@ -38,6 +38,9 @@ export const GET_EVENT_ATTENDENCE = 'GET_EVENT_ATTENDENCE';
 // Constants specific to interests
 export const INTERESTS = 'INTERESTS';
 export const INTEREST = 'INTEREST';
+export const CREATE_INTERESTS = 'CREATE_INTERESTS'
+export const REMOVE_INTERESTS = 'REMOVE_INTERESTS';
+export const JOINED_CATEGORIES = 'JOINED_CATEGORIES';
 
 // Constants specific to slack channels
 export const CHANNELS = 'CHANNELS';

--- a/client/actions/graphql/categoryGQLActions.js
+++ b/client/actions/graphql/categoryGQLActions.js
@@ -30,7 +30,7 @@ export const getCategoryList = ({
     description_Istartswith
   )
 ).then(data => dispatch(getClubs(data.data.categoryList.edges)))
-.catch(error => handleError(error, dispatch));
+  .catch(error => handleError(error, dispatch));
 
 export const getCategory = id => ({
   type: GET_CLUB,
@@ -41,23 +41,23 @@ export const getCategory = id => ({
 export const joinedClubsGQL = () => dispatch => Client.query(
   JOINED_CLUBS_GQL()
 ).then(data => dispatch({
-    type: JOINED_CLUBS,
-    payload: data.data,
-    error: false,
-  })).catch(error => handleError(error, dispatch));
+  type: JOINED_CLUBS,
+  payload: data.data,
+  error: false,
+})).catch(error => handleError(error, dispatch));
 
 export const joinSocialClub = (clubId, clientMutationId = '') => dispatch => Client.mutate(
   JOIN_SOCIAL_CLUB_GQL(clubId, clientMutationId)
 ).then(data => dispatch({
-    type: JOIN_CLUB,
-    payload: data.data,
-    error: false,
-  })).catch(error => handleError(error, dispatch));
+  type: JOIN_CLUB,
+  payload: data.data,
+  error: false,
+})).catch(error => handleError(error, dispatch));
 
 export const unjoinSocialClub = (clubId, clientMutationId = '') => dispatch => Client.mutate(
   UNJOIN_SOCIAL_CLUB_GQL(clubId, clientMutationId)
 ).then(data => dispatch({
-    type: UNJOIN_CLUB,
-    payload: data.data,
-    error: false,
-  })).catch(error => handleError(error, dispatch));
+  type: UNJOIN_CLUB,
+  payload: data.data,
+  error: false,
+})).catch(error => handleError(error, dispatch));

--- a/client/actions/graphql/interestGQLActions.js
+++ b/client/actions/graphql/interestGQLActions.js
@@ -1,20 +1,25 @@
 import INTERESTS_LIST_GQL from '../../Graphql/Queries/InterestsListGQL';
 import CALENDAR_URL_GQL from '../../Graphql/Queries/CalendarAuthGQL';
+import CREATE_INTEREST_GQL from '../../Graphql/Mutations/CreateInterestGQL';
+import REMOVE_INTEREST_GQL from '../../Graphql/Mutations/RemoveInterestGQL';
+import JOINED_CATEGORIES_GQL from '../../Graphql/Queries/JoinedCategoriesGQL';
 
-import { INTEREST, INTERESTS } from '../constants';
-
-import { handleError } from '../../utils/errorHandler';
+import { INTEREST, INTERESTS, CREATE_INTERESTS, REMOVE_INTERESTS, JOINED_CATEGORIES } from '../constants';
+import { handleError, handleInformation } from '../../utils/errorHandler';
 import Client from '../../client';
 
 
 export const getInterestsList = (before = '', after = '', first = 1, last = 1) => dispatch => Client.query(
-  INTERESTS_LIST_GQL(before, after, first, last)
-).then(data => dispatch({
-  type: INTERESTS,
-  payload: data.data,
-  error: false
-}))
-.catch(error => handleError(error, dispatch));
+  INTERESTS_LIST_GQL()
+).then(data => {
+  dispatch({
+    type: INTERESTS,
+    payload: data.data,
+    error: false
+  }
+  )
+})
+  .catch(error => handleError(error, dispatch));
 
 export const getInterest = id => ({
   type: INTEREST,
@@ -28,4 +33,37 @@ export const getCalendarUrl = () => dispatch => Client.query(CALENDAR_URL_GQL())
     return authUrl
   })
   .catch(error => handleError(error, dispatch));
+export const getUserInterests = () => dispatch => Client.query(
+  JOINED_CATEGORIES_GQL()
+).then(data => {
+  dispatch({
+    type: JOINED_CATEGORIES,
+    payload: data.data,
+    error: false,
+  })
+}).catch(error => handleError(error, dispatch));
 
+
+export const createInterests = (interestsId, clientMutationId = '') => dispatch => Client.mutate(CREATE_INTEREST_GQL(interestsId, clientMutationId))
+  .then((data) => {
+    dispatch({
+      type: CREATE_INTERESTS,
+      payload: data.joinedCategoryList,
+      error: false,
+    });
+    handleInformation('Successfully Created Interests');
+  })
+  .catch(error => handleError(error, dispatch));
+
+
+export const removeInterests = (interestsId, clientMutationId = '') => dispatch => Client.mutate(REMOVE_INTEREST_GQL(interestsId, clientMutationId))
+  .then((data) => {
+    dispatch({
+      type: REMOVE_INTERESTS,
+      payload: data.unjoinedCategories,
+      error: false,
+    });
+    handleInformation('Successfully Removed Interests');
+
+  })
+  .catch(error => handleError(error, dispatch));

--- a/client/components/cards/InterestCard.jsx
+++ b/client/components/cards/InterestCard.jsx
@@ -4,20 +4,20 @@ import PropTypes from 'prop-types';
 const InterestCard = (props) => {
   const {
     name,
-    index,
+    category,
     active,
     handleClick
   } = props;
-
   return (
-    <div onClick={() => handleClick(index)} className={`interests-card ${active ? 'active' : ''}`}>
+    <div onClick={() => {
+      handleClick(category)}} className={`interests-card ${active ? 'active' : ''}`}>
       <p>{name}</p>
-      {!!active && <span className="interests-card__icon-close"  onClick={
+      {active && <span className="interests-card__icon-close"  onClick={
         (e) => {
           e.stopPropagation();
-          handleClick(index, false)
+          handleClick(category, true)
         }
-      }>
+      }> 
         <div className="interest-icon">close</div>
       </span>}
       {!active && <span className="interests-card__icon-check interest-icon">check</span>}
@@ -27,7 +27,6 @@ const InterestCard = (props) => {
 
 InterestCard.propTypes = {
   name: PropTypes.string.isRequired,
-  index: PropTypes.number.isRequired,
   active: PropTypes.bool.isRequired,
   handleClick: PropTypes.func.isRequired,
 };

--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -110,7 +110,14 @@ class Dashboard extends Component {
   redirectUser = () => {
     const { location: { pathname } } = this.props;
     if (pathname === '/') {
-      return <Redirect to="/dashboard" />;
+      const isFirstLogin = localStorage.getItem('checkFirstLogin');
+      
+      if (isFirstLogin === 'No') {
+        return (<Redirect to="/events" />);
+      } else {
+        localStorage.setItem('checkFirstLogin', 'No')
+        return <Redirect to="/interests" />;
+      }
     }
   };
 
@@ -150,7 +157,7 @@ class Dashboard extends Component {
     if (isTokenExpired() || !isLoggedIn()) {
       return <Redirect to={{
         pathname: '/login',
-        state: {"previousLocation": window.location.href}
+        state: { "previousLocation": window.location.href }
       }} />;
     }
 

--- a/client/pages/Login/index.js
+++ b/client/pages/Login/index.js
@@ -9,7 +9,6 @@ import dotenv from 'dotenv';
 // utils
 import isLoggedIn from '../../utils/isLoggedIn';
 
-
 dotenv.config();
 
 /**

--- a/client/reducers/interestReducers.js
+++ b/client/reducers/interestReducers.js
@@ -3,6 +3,8 @@ import {
   INTEREST,
   INTERESTS,
   SIGN_OUT,
+  CREATE_INTERESTS,
+  JOINED_CATEGORIES,
 } from '../actions/constants';
 
 /**
@@ -13,6 +15,8 @@ import {
  */
 const interests = (state = initialState.interests, action) => {
   switch (action.type) {
+
+    case JOINED_CATEGORIES:
     case INTERESTS:
       return Object.assign({}, state, { interests: action.payload });
 
@@ -25,6 +29,9 @@ const interests = (state = initialState.interests, action) => {
             .filter(item => item.node.id === action.payload.id),
         }
       );
+
+    case CREATE_INTERESTS:
+      return Object.assign({}, state, { interests: action.payload });
 
     case SIGN_OUT:
       return Object.assign({}, state, {

--- a/client/routes.js
+++ b/client/routes.js
@@ -21,7 +21,7 @@ const Dashboard = LoadComponent(import('./pages/Dashboard'));
 const Routes = () => (
   <Switch>
     <Route exact path="/login" component={Login} />
-    <Route exact path="/TestActions" component={TestActions}/>
+    <Route exact path="/TestActions" component={TestActions} />
     <Route path="/" component={Dashboard} />
     <Route path="*" component={NotFound} />
   </Switch>


### PR DESCRIPTION
#### What Does This PR Do?
This PR adds functionality for adding interests on the first login.

#### Description Of Task To Be Completed
- add create interests action
- add create interests reducer
- add functionality to interest card

#### Any Background Context You Want To Provide?
On the first login, users will be directed to interests page and directed to the dashboard for subsequent logins

#### How can this be manually tested?
-  checkout  `mv-develop` and pull
- checkout to `ft-userAddInterest-165977941`
-  clear your browser local storage and re-login
- then you will be directed to interests page to select interests

#### What are the relevant pivotal tracker stories?
[#165977941](https://www.pivotaltracker.com/story/show/165977941)

#### Screenshot(s)
