### PR TITLE
#165998972 Implement adding of attendee to event's slack channel on attend action

### DIFF
--- a/server/api/slack.py
+++ b/server/api/slack.py
@@ -2,6 +2,7 @@ import dotenv
 
 from slackclient import SlackClient
 from os import getenv
+
 dotenv.load()
 
 # instantiate Slack & Twilio clients
@@ -164,3 +165,11 @@ def get_slack_channels_list(limit=100):
         # retrieve all slack channels
         return channels_list
     return ''
+
+
+def invite_to_event_channel(user_id, event_channel, channel_creator_token):
+    return SlackClient(channel_creator_token).api_call(
+            "channels.invite",
+            channel=event_channel,
+            user=user_id,
+        )


### PR DESCRIPTION
#### What Does This PR Do?
- This PR implements adding an attendee to an event's slack channel when they perform the "attend" action
#### Description Of Task To Be Completed
- [x] For any event that has a slack_channel, when a user performs the "attend" action,
they should be invited to the corresponding event channel.
#### Any Background Context You Want To Provide?
This PR depends on the implementation that adds a slack channel for an event - https://github.com/AndelaOSP/Andela-Socials/pull/197
#### How can this be manually tested?
- Perform the "attend" action on an event created that has a slack channel, and you should be automatically added to the slack channel
#### What are the relevant pivotal tracker stories?
[#165998972](https://www.pivotaltracker.com/n/projects/2174978)
#### Screenshot(s)
