### PR TITLE
#166153570 (feat): Event host should be able to connect the App to slack explicitly

### DIFF
--- a/client/Graphql/Mutations/CreateEventGQL.js
+++ b/client/Graphql/Mutations/CreateEventGQL.js
@@ -29,6 +29,7 @@ const CREATE_EVENT_GQL = (
           }
           active
         }
+        slackToken
         clientMutationId
       }
     }`,

--- a/client/actions/constants.js
+++ b/client/actions/constants.js
@@ -50,3 +50,6 @@ export const VALIDATE_INVITE = 'VALIDATE_INVITE';
 
 // Constants to sahre events to slack channel
 export const SHARE_EVENT = 'SHARE_EVENT';
+
+// Constant to display slack modal
+export const SLACK_TOKEN = 'SLACK_TOKEN';

--- a/client/actions/graphql/eventGQLActions.js
+++ b/client/actions/graphql/eventGQLActions.js
@@ -14,6 +14,7 @@ import {
   DEACTIVATE_EVENT,
   SEARCH_EVENTS,
   SHARE_EVENT,
+  SLACK_TOKEN,
 } from '../constants';
 
 import { handleError, handleInformation } from '../../utils/errorHandler';
@@ -69,9 +70,14 @@ export const createEvent = ({
     timezone,
     categoryId
   )
-).then(data => dispatch({
-  type: CREATE_EVENT, payload: data.data, error: false,
-}))
+).then((data) => {
+  dispatch({
+    type: SLACK_TOKEN, payload: data.data.createEvent,
+  });
+  dispatch({
+    type: CREATE_EVENT, payload: data.data, error: false,
+  });
+})
   .catch((error) => {
     if (error.toString().includes('Calendar API not authorized')) {
       const authUrl = error.graphQLErrors[0].AuthUrl;
@@ -129,10 +135,10 @@ export const shareEvent = ({
   channelId,
 }) => dispatch => Client.mutate(
   SHARE_EVENT_GQL(eventId, channelId)
-).then(data => {
+).then((data) => {
   handleInformation('Successfully shared');
   dispatch({
     type: SHARE_EVENT, payload: data.data, error: false,
-  })
+  });
 })
   .catch(error => handleError(error, dispatch));

--- a/client/components/Modals/ModalContainer.js
+++ b/client/components/Modals/ModalContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { ModalContextCreator } from './ModalContext';
 import EventForm from '../Forms/EventForm';
 import DeleteForm from '../Forms/DeleteForm';
+import SlackModal from './SlackModal';
 
 /*
   maps a string to a modal child, used to determine
@@ -16,12 +17,16 @@ const MODAL_COMPONENTS = {
   CREATE_EVENT: EventForm,
   UPDATE_EVENT: EventForm,
   DELETE_EVENT: DeleteForm,
+  SLACK_MODAL: SlackModal,
 };
 
 const ModalContent = (props) => {
-  const { modalProps, closeModal, activeModal } = props;
+  const {
+    modalProps, closeModal, activeModal,
+  } = props;
   const SpecificModal = MODAL_COMPONENTS[activeModal];
-  const submitText = activeModal === 'DELETE_EVENT' ? 'CONFIRM' : 'Submit';
+  const submitText = (activeModal === 'DELETE_EVENT' || activeModal === 'SLACK_MODAL')
+    ? 'CONFIRM' : 'Submit';
   return (
     <div className="modal__content">
       <header className="modal__header">

--- a/client/components/Modals/ModalContext.js
+++ b/client/components/Modals/ModalContext.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { SLACK_TOKEN } from '../../actions/constants';
 
 export const ModalContextCreator = React.createContext();
 
@@ -8,6 +10,7 @@ class ModalContext extends Component {
     'CREATE_EVENT',
     'UPDATE_EVENT',
     'DELETE_EVENT',
+    'SLACK_MODAL',
   ];
 
   defaultModalProps = { modalHeadline: 'default modal headline' };
@@ -31,7 +34,17 @@ class ModalContext extends Component {
     });
   };
 
+  closeSlackModal = () => {
+    const { dispatch } = this.props;
+    dispatch({
+      type: SLACK_TOKEN,
+      payload: { slackToken: true },
+    });
+  }
+
   closeModal = () => {
+    const { activeModal } = this.state;
+    if (activeModal === 'SLACK_MODAL') this.closeSlackModal();
     document.getElementsByTagName('body')[0].classList.remove('no-scroll');
     this.setState({ activeModal: null });
   };
@@ -58,4 +71,4 @@ class ModalContext extends Component {
 
 ModalContext.propTypes = { children: PropTypes.node.isRequired };
 
-export default ModalContext;
+export default connect()(ModalContext);

--- a/client/components/Modals/SlackModal.jsx
+++ b/client/components/Modals/SlackModal.jsx
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+class SlackModal extends Component {
+  formSubmitHandler = (e) => {
+    const { dismiss } = this.props;
+    e.preventDefault();
+    dismiss();
+    window.location.href = '/api/v1/slack/authorize';
+  }
+
+  render() {
+    const { formId } = this.props;
+    return (
+      <form
+        id={formId}
+        onSubmit={this.formSubmitHandler}>
+        <p style={{ fontWeight: 400 }}>
+          To add your event to a slack channel we need you to connect to slack first.
+        </p>
+      </form>
+    );
+  }
+}
+
+SlackModal.propTypes = {
+  dismiss: PropTypes.func.isRequired,
+  formId: PropTypes.string.isRequired,
+};
+
+export default connect()(SlackModal);

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -28,6 +28,7 @@ class EventsPage extends React.Component {
       selectedCategory: '',
       eventStartDate: formatDate(Date.now(), 'YYYY-MM-DD'),
       lastEventItemCursor: '',
+      slackToken: true,
     };
     this.getFilteredEvents = this.getFilteredEvents.bind(this);
   }
@@ -50,7 +51,7 @@ class EventsPage extends React.Component {
     const {
       events: {
         eventList, pageInfo: { hasNextPage },
-      }, socialClubs,
+      }, socialClubs, slackToken,
     } = nextProps;
     const eventLength = eventList.length;
     const lastEventItemCursor = eventLength ? eventList[eventLength - 1].cursor : '';
@@ -59,6 +60,7 @@ class EventsPage extends React.Component {
       hasNextPage,
       categoryList: socialClubs.socialClubs,
       lastEventItemCursor,
+      slackToken,
     });
   }
 
@@ -195,6 +197,24 @@ class EventsPage extends React.Component {
     </ModalContextCreator.Consumer>
   );
 
+  openSlackModal = () => (
+    <ModalContextCreator.Consumer>
+      {
+        ({
+          activeModal,
+          openModal,
+        }) => {
+          const { slackToken } = this.state;
+          if (activeModal || slackToken) return null;
+          openModal('SLACK_MODAL', {
+            modalHeadline: 'Connect App to Slack',
+            formId: 'slack-form',
+          });
+        }
+      }
+    </ModalContextCreator.Consumer>
+  );
+
   render() {
     const {
       categoryList,
@@ -215,6 +235,7 @@ class EventsPage extends React.Component {
           </div>
         </div>
         {this.renderEventGallery()}
+        {this.openSlackModal()}
         <div className={`event__footer ${hasNextPage ? '' : 'event__footer--hidden'}`} >
           <button onClick={this.loadMoreEvents} type="button" className="btn-blue event__load-more-button">
             Load more
@@ -233,6 +254,7 @@ EventsPage.propTypes = { categories: PropTypes.arrayOf(PropTypes.shape({})) };
 const mapStateToProps = state => ({
   events: state.events,
   socialClubs: state.socialClubs,
+  slackToken: state.slackToken,
 });
 
 export default connect(mapStateToProps, {

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -13,6 +13,7 @@ import url from './urlReducers';
 import userReducers from './userReducers';
 import { inviteValidation } from './inviteReducers';
 import oauth from './oauthReducers';
+import slackToken from './slackTokenReducer';
 
 const rootReducer = {
   activeUser: userReducers,
@@ -28,7 +29,8 @@ const rootReducer = {
   url,
   oauth,
   invite: inviteValidation,
-  slackChannels
+  slackChannels,
+  slackToken,
 };
 
 export default rootReducer;

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -14,5 +14,6 @@ export default {
   eventsSearchList: [],
   oauth: '',
   invite: {},
-  slackChannels: {}
+  slackChannels: {},
+  slackToken: true,
 };

--- a/client/reducers/slackTokenReducer.js
+++ b/client/reducers/slackTokenReducer.js
@@ -1,0 +1,14 @@
+import initialState from './initialState';
+import { SLACK_TOKEN } from '../actions/constants';
+
+
+const slackTokenReducer = (state = initialState.slackToken, action) => {
+  switch (action.type) {
+    case SLACK_TOKEN:
+      return action.payload.slackToken;
+    default:
+      return state;
+  }
+};
+
+export default slackTokenReducer;

--- a/server/graphql_schemas/event/schema.py
+++ b/server/graphql_schemas/event/schema.py
@@ -70,6 +70,7 @@ class CreateEvent(relay.ClientIDMutation):
         slack_channel = graphene.String(required=False)
 
     new_event = graphene.Field(EventNode)
+    slack_token = graphene.Boolean()
 
     @staticmethod
     def create_event(category, user_profile, **input):
@@ -113,8 +114,16 @@ class CreateEvent(relay.ClientIDMutation):
         except ValueError as e:
             raise GraphQLError("An Error occurred. \n{}".format(e))
 
+        slack_token = False
+        if (user_profile.slack_token):
+            slack_token = True
+        new_event.slack_token = user_profile.slack_token
+
         CreateEvent.notify_event_in_slack(category, input, new_event)
-        return cls(new_event=new_event)
+        return cls(
+            slack_token=slack_token,
+            new_event=new_event
+        )
 
     @staticmethod
     def notify_event_in_slack(category, input, new_event):


### PR DESCRIPTION
#### What Does This PR Do?
- adds a modal that has instructions to connect to slack

#### Description Of Task To Be Completed
- As an event host, I should be able to explicitly connect the Andela Social app to Slack. After creating an event, if I am not already connected, then I should see a modal that prompts me to connect the Andela social app to Slack.

#### Any Background Context You Want To Provide?
- N/A

#### How can this be manually tested?
- on the frontend console create a new event.
- if a slack token isn't found on the db the response will trigger the slack modal to pop up
- if you click cancel, the modal disappears
- if you click on confirm, you are redirected to a slack auth page to confirm

#### What are the relevant pivotal tracker stories?
[#166153570 Event host should be able to connect the App to slack explicitly](https://www.pivotaltracker.com/story/show/166153570)

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/28973383/58793285-773a2f00-85fe-11e9-82d1-255ee8da6ee5.png)

![image](https://user-images.githubusercontent.com/28973383/59023642-e14e1080-8858-11e9-88f2-74f12228d191.png)
