### PR TITLE
#166220689 Enable bulk removal of user interests

### DIFF
--- a/client/assets/pages/_events-page.scss
+++ b/client/assets/pages/_events-page.scss
@@ -339,15 +339,6 @@ main {
     font-weight: 300;
     display: inline-block;
     position: relative;
-    &:after {
-      content: "";
-      position: absolute;
-      width: 75%;
-      height: 1px;
-      bottom: 0;
-      left: 1%;
-      border-bottom: 4px solid rgba(51, 89, 219, 1);
-    }
   }
   &__box {
     padding: 5px;


### PR DESCRIPTION
#### What Does This PR Do?
- Enables bulk removal of user interests

#### Description Of Task To Be Completed
 - Modify unjoinCategory mutation resolver
 - Fix bug with empty joinedCategories query
 - Remove border from Filter label

#### Any Background Context You Want To Provide?
 - Previously the unJoinCategory mutation only allowed input for a single category

#### How can this be manually tested?
- Start the app
- Navigate to the GraphiQL playground at `/graphql`
- Get a user's current interestList with the joinedCategories query
- Use the unjoinCategory mutation in the screenshot below to remove a list of interests

#### What are the relevant pivotal tracker stories?
[#166220689](https://www.pivotaltracker.com/story/show/166220689)

#### Screenshot(s)
<img width="1081" alt="Screenshot 2019-05-23 at 9 58 29 AM" src="https://user-images.githubusercontent.com/30433120/58275170-5404b980-7d8c-11e9-9c1e-a85c4b0fc969.png">
