### PR TITLE
#165999274 Implement calendar access on interest page

### DIFF
--- a/client/Graphql/Queries/CalendarAuthGQL.js
+++ b/client/Graphql/Queries/CalendarAuthGQL.js
@@ -1,0 +1,13 @@
+import gql from 'graphql-tag';
+
+const CALENDAR_URL_GQL = () => ({
+  query: gql`
+    query{
+      calendarAuth{
+        authUrl
+      }
+    }
+    `
+});
+
+export default CALENDAR_URL_GQL;

--- a/client/actions/graphql/interestGQLActions.js
+++ b/client/actions/graphql/interestGQLActions.js
@@ -1,4 +1,5 @@
 import INTERESTS_LIST_GQL from '../../Graphql/Queries/InterestsListGQL';
+import CALENDAR_URL_GQL from '../../Graphql/Queries/CalendarAuthGQL';
 
 import { INTEREST, INTERESTS } from '../constants';
 
@@ -21,4 +22,10 @@ export const getInterest = id => ({
   error: false
 });
 
+export const getCalendarUrl = () => dispatch => Client.query(CALENDAR_URL_GQL())
+  .then(({ data }) => {
+    const { authUrl }= data.calendarAuth;
+    return authUrl
+  })
+  .catch(error => handleError(error, dispatch));
 

--- a/client/assets/components/modalContainer.scss
+++ b/client/assets/components/modalContainer.scss
@@ -44,11 +44,14 @@
     }
   }
 
+  .modal__form-text {
+    font-size: rem(20px);
+  }
+
   .modal__body {
     margin-top: rem(20px);
     margin-bottom: rem(30px);
   }
-
 
   .modal__btns {
     display: flex;
@@ -65,7 +68,7 @@
       max-width: rem(130px);
       text-transform: uppercase;
       letter-spacing: 0.019rem;
-      line-height:rem(15px);
+      line-height: rem(15px);
 
       &.modal__btn-cancel {
         color: $blue;
@@ -74,7 +77,7 @@
 
       &.modal__btn-submit {
         background-color: $blue;
-        color: #fff;
+        color: #FFF;
       }
     }
   }

--- a/client/components/Forms/SubmitForm.js
+++ b/client/components/Forms/SubmitForm.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class SubmitForm extends Component {
+  formSubmitHandler = (e) => {
+    e.preventDefault();
+    this.props.submitForm();
+  }
+
+  render() {
+    const { formText } = this.props;
+    return (
+      <form
+        id="submit-event-form"
+        onSubmit={this.formSubmitHandler}
+      >
+        <div className="modal__form-text">{formText}</div>
+      </form>
+    );
+  }
+}
+
+SubmitForm.propTypes = {
+  formText: PropTypes.string,
+  submitForm: PropTypes.func.isRequired,
+};
+
+export default SubmitForm;

--- a/client/components/Modals/ModalContainer.js
+++ b/client/components/Modals/ModalContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { ModalContextCreator } from './ModalContext';
 import EventForm from '../Forms/EventForm';
 import DeleteForm from '../Forms/DeleteForm';
+import SubmitForm from '../Forms/SubmitForm';
 
 /*
   maps a string to a modal child, used to determine
@@ -16,12 +17,19 @@ const MODAL_COMPONENTS = {
   CREATE_EVENT: EventForm,
   UPDATE_EVENT: EventForm,
   DELETE_EVENT: DeleteForm,
+  SUBMIT_INVITE: SubmitForm,
 };
 
 const ModalContent = (props) => {
   const { modalProps, closeModal, activeModal } = props;
+
+  const submitButtonLabels = {
+    DELETE_EVENT: 'CONFIRM',
+    SUBMIT_INVITE: 'CONFIRM'
+  };
+  const submitText = submitButtonLabels[activeModal] || 'Submit';
+
   const SpecificModal = MODAL_COMPONENTS[activeModal];
-  const submitText = activeModal === 'DELETE_EVENT' ? 'CONFIRM' : 'Submit';
   return (
     <div className="modal__content">
       <header className="modal__header">
@@ -34,7 +42,7 @@ const ModalContent = (props) => {
         <button
           className="modal__btn modal__btn-cancel"
           type="button"
-          onClick={closeModal}
+          onClick={modalProps.cancel || closeModal}
         >Cancel</button>
         <button
           className="modal__btn modal__btn-submit"

--- a/client/components/Modals/ModalContext.js
+++ b/client/components/Modals/ModalContext.js
@@ -8,6 +8,7 @@ class ModalContext extends Component {
     'CREATE_EVENT',
     'UPDATE_EVENT',
     'DELETE_EVENT',
+    'SUBMIT_INVITE'
   ];
 
   defaultModalProps = { modalHeadline: 'default modal headline' };

--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -183,7 +183,7 @@ class Dashboard extends Component {
               render={props => <EventDetailsPage {...props} activeUser={activeUser} categories={categories} updateEvent={updateEvent} uploadImage={uploadImage} />}
             />
             <Route path="/invite/:inviteHash" component={Invite} />
-            <Route path="/events" render={() => <EventsPage />} />
+            <Route path="/events" render={() => <EventsPage createEvent={createEvent} categories={categories} uploadImage={uploadImage} />} />
             <Route path="/dashboard" render={() => <EventsPage createEvent={createEvent} categories={categories} uploadImage={uploadImage} />} />
             <Route path="/interests" render={() => <Interests />} />
             <Route path="*" component={NotFound} />

--- a/client/pages/Interests/index.jsx
+++ b/client/pages/Interests/index.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import InterestCard from '../../components/cards/InterestCard';
 import interests from '../../fixtures/interests';
+import { withRouter } from 'react-router-dom';
+import { ModalContextCreator } from '../../components/Modals/ModalContext';
+
+//actions
+import { getCalendarUrl } from '../../actions/graphql/interestGQLActions';
 
 /**
  * @description allows users to select their interests
@@ -10,6 +15,9 @@ import interests from '../../fixtures/interests';
  * @extends {React.Component}
  */
 class Interests extends React.Component {
+  constructor(props, context){
+    super(props, context);
+  }
   state = {
     interests,
   }
@@ -32,6 +40,46 @@ class Interests extends React.Component {
       interests,
     });
   }
+
+  queryCalendarUrl = () => {
+    this.props.getCalendarUrl()
+     .then(authUrl => {
+       if(authUrl){
+        window.location.href = authUrl
+       }
+      });
+  }
+
+  redirectToHomePage = (closeModal) => {
+    closeModal();
+    this.props.history.push('/dashboard');
+  }
+
+  showAuthenticateModal = () => (
+    <ModalContextCreator.Consumer>
+      {({
+        activeModal, openModal, closeModal
+      }) => {
+        if (activeModal) return null;
+        return (
+          <button
+            type="button"
+            className="interests__btn interests__btn-submit"
+            onClick={() => openModal('SUBMIT_INVITE', {
+              modalHeadline: 'Authenticate Calendar',
+              formText: `Authenticate Andela socials to have access to your Andela calendar`,
+              formId: 'submit-event-form',
+              submitForm: this.queryCalendarUrl,
+              cancel: () => this.redirectToHomePage(closeModal),
+            })
+            }
+          >
+            Submit
+          </button>
+        );
+      }}
+    </ModalContextCreator.Consumer>
+  );
   
   render() {
     const { interests } = this.state;
@@ -57,9 +105,7 @@ class Interests extends React.Component {
             className="interests__btn interests__btn-cancel"
             type="button"
           >Cancel</button>
-          <button
-            className="interests__btn interests__btn-submit"
-          >Submit</button>
+          {this.showAuthenticateModal()}
         </footer>
       </div>
     );
@@ -69,4 +115,6 @@ class Interests extends React.Component {
 const mapStateToProps = state => ({
 });
 
-export default connect(mapStateToProps, {})(Interests);
+export default connect(mapStateToProps, {
+  getCalendarUrl
+})(withRouter(Interests));


### PR DESCRIPTION
#### What Does This PR Do?
   This PR implements calendar access granting capability from the interests page

#### Description Of Task To Be Completed
    - add google access modal
    - add calendar access query
    - add calendar access actions

#### Any Background Context You Want To Provide?
NONE

#### How can this be manually tested?
Checkout to ft-explicitly-grant-calendar-access-165999274

#### What are the relevant pivotal tracker stories?
[#165999274](https://www.pivotaltracker.com/story/show/165999274)

#### Screenshot(s)
<img width="1678" alt="Screenshot 2019-05-26 at 5 37 55 PM" src="https://user-images.githubusercontent.com/19429611/58384727-08951a00-7fdd-11e9-8d51-dbe7e4b43247.png">
