### PR TITLE
#166287672 Fix event creation modal jumping off screen

### DIFF
--- a/client/assets/components/modalContainer.scss
+++ b/client/assets/components/modalContainer.scss
@@ -1,9 +1,7 @@
 .modal {
-  position: absolute;
   top: 0;
   left: 0;
   height: 100vh;
-  // bottom: 0;
   right: 0;
   background-color: rgba(0, 0, 0, 0.64);
   display: flex;
@@ -13,7 +11,7 @@
   z-index: 1040;
 
   .modal__content {
-    background-color: #fff;
+    background-color: #FFF;
     padding: rem(25px);
     width: 90%;
     max-width: rem(768px);


### PR DESCRIPTION
#### What Does This PR Do?
     This PR fixes event creation modal jumping off the screen when page is scrolled

#### Description Of Task To Be Completed
    - remove position  absolute from the modal styles

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
  1. checkout to `bg-fix-modal-jumping-off-screen-166287672`
  2. On the dashboard page scroll down, then click on floating action button
  3. Then you will see a full event creation button regardless of how far down you are on the screen
#### What are the relevant pivotal tracker stories?
[#166287672](https://www.pivotaltracker.com/story/show/166287672)

#### Screenshot(s)
