### PR TITLE
#166491349 prevent sidenav hiding below the navbar

### DIFF
--- a/client/actions/constants.js
+++ b/client/actions/constants.js
@@ -48,5 +48,8 @@ export const OAUTH = 'OAUTH';
 // Constants Invites
 export const VALIDATE_INVITE = 'VALIDATE_INVITE';
 
-// Constants to sahre events to slack channel
+// Constants to share events to slack channel
 export const SHARE_EVENT = 'SHARE_EVENT';
+
+// Constants specific to ui events
+export const SUBNAV_HIDDEN = 'SUBNAV_HIDDEN';

--- a/client/actions/uiActions.js
+++ b/client/actions/uiActions.js
@@ -1,0 +1,10 @@
+import { SUBNAV_HIDDEN } from './constants';
+
+export const hideSubNav = (payload) => {
+  return (dispatch) => {
+    dispatch({
+      type: SUBNAV_HIDDEN,
+      payload,
+    });
+  };
+}

--- a/client/assets/pages/_events-page.scss
+++ b/client/assets/pages/_events-page.scss
@@ -21,13 +21,24 @@
     grid-column: sidebar-start/sidebar-end;
     width: rem(330px);
     vertical-align: middle;
+    justify-self: center;
     &-fixed {
       position: fixed;
       width: 20.625rem;
-      top: 5.2rem;
+      height: 100vh;
+      top: 0;
+      overflow-y: scroll;
+      padding-top: 10rem;
+      transition: padding-top .5s ease-in-out;
+      will-change: padding-top;
       @include mobile(600px) {
         position: initial;
+        height: initial;
+        padding-top: initial;
       }
+    }
+    &-fixed.event__sidebar-expanded {
+      padding-top: 5rem;
     }
   }
 

--- a/client/components/common/SubNav.js
+++ b/client/components/common/SubNav.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { hideSubNav } from '../../actions/uiActions';
 
 const NavMenu = ({
   to,
@@ -20,7 +22,6 @@ NavMenu.propTypes = {
 class SubNav extends Component {
   state = {
     currentBodyScroll: 0,
-    hideSubNav: false,
   }
   componentDidMount = () => {
     this.scrollableBody = document.querySelector('body');
@@ -31,15 +32,17 @@ class SubNav extends Component {
   }
   onBodyScroll = () => {
     const { scrollTop } = this.scrollableBody;
-    this.setState(({ currentBodyScroll }) => ({
-      hideSubNav: scrollTop > currentBodyScroll ? true : false,
-      currentBodyScroll: scrollTop,
-    }));
+    this.setState(({ currentBodyScroll }) => {
+    this.props.hideSubNav(scrollTop > currentBodyScroll ? true : false);
+    return {
+        currentBodyScroll: scrollTop,
+      };
+    });
   }
   render() {
-    const { hideSubNav } = this.state;
+    const { subNavHidden } = this.props;
     return (
-      <div className={`navbar ${hideSubNav ? 'navbar-hide' : ''}`}>
+      <div className={`navbar ${subNavHidden ? 'navbar-hide' : ''}`}>
         <div className="navbar__bottom-section">
           <NavMenu to="/dashboard">Dashboard</NavMenu>
         </div>
@@ -48,4 +51,7 @@ class SubNav extends Component {
   }
 }
 
-export default SubNav;
+const mapStateToProps = state => ({
+  subNavHidden: state.uiReducers.subNavHidden,
+});
+export default connect(mapStateToProps, { hideSubNav })(SubNav);

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -201,6 +201,7 @@ class EventsPage extends React.Component {
       categoryList,
       hasNextPage,
     } = this.state;
+    const { subNavHidden } = this.props;
     const catList = Array.isArray(categoryList) ? categoryList.map(item => ({
       id: item.node.id,
       title: item.node.name,
@@ -210,7 +211,7 @@ class EventsPage extends React.Component {
     return (
       <div className="event__container">
         <div className="event__sidebar">
-          <div className="event__sidebar-fixed">
+          <div className={`event__sidebar-fixed ${subNavHidden ? 'event__sidebar-expanded' : ''}`}>
             <EventFilter categoryList={catList} filterSelected={this.getFilteredEvents} />
             <Calendar dateSelected={this.getFilteredEvents} />
           </div>
@@ -234,6 +235,7 @@ EventsPage.propTypes = { categories: PropTypes.arrayOf(PropTypes.shape({})) };
 const mapStateToProps = state => ({
   events: state.events,
   socialClubs: state.socialClubs,
+  subNavHidden: state.uiReducers.subNavHidden,
 });
 
 export default connect(mapStateToProps, {

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -11,6 +11,7 @@ import interests from './interestReducers';
 import slackChannels from './slackChannelsReducers';
 import url from './urlReducers';
 import userReducers from './userReducers';
+import uiReducers from './uiReducers';
 import { inviteValidation } from './inviteReducers';
 import oauth from './oauthReducers';
 
@@ -28,7 +29,8 @@ const rootReducer = {
   url,
   oauth,
   invite: inviteValidation,
-  slackChannels
+  slackChannels,
+  uiReducers,
 };
 
 export default rootReducer;

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -14,5 +14,8 @@ export default {
   eventsSearchList: [],
   oauth: '',
   invite: {},
-  slackChannels: {}
+  slackChannels: {},
+  ui: {
+    subNavHidden: false,
+  },
 };

--- a/client/reducers/uiReducers.js
+++ b/client/reducers/uiReducers.js
@@ -1,0 +1,19 @@
+import { SUBNAV_HIDDEN } from '../actions/constants';
+import initialState from './initialState';
+
+/**
+ * Reducer for ui events
+ * @param {object} [state=initialState.ui]
+ * @param {object} action
+ * @returns {object} new state with invite details
+ */
+export const uiReducers = (state = initialState.ui, { type, payload }) => {
+  switch (type) {
+    case SUBNAV_HIDDEN:
+      return { subNavHidden: payload };
+    default:
+      return state;
+  }
+};
+
+export default uiReducers;

--- a/client/store/configureStore.js
+++ b/client/store/configureStore.js
@@ -6,8 +6,8 @@ import storage from 'redux-persist/es/storage';
 import rootReducer from '../reducers/index';
 import saveTokenMiddleware from '../middleware/auth';
 
-
-const config = { key: 'root', storage };
+// blacklist ui state so they're not persisted
+const config = { key: 'root', storage, blacklist: ['uiReducers'] };
 const reducers = persistCombineReducers(config, rootReducer);
 const middleware = [thunk, saveTokenMiddleware];
 


### PR DESCRIPTION
#### What Does This PR Do?
This PR fixes the UI/UX issue of sidebar hiding below the navbar

#### Description Of Task To Be Completed
- add sidenav visibility state to redux store
- allow sidenav to scroll
- expand sidenav when subnav hides
- prevent uiStates from being persisted in localstorage

#### Any Background Context You Want To Provide?
sidenav is currently being shadowed when subnav is visible.

#### How can this be manually tested?
- clone the repo, switch to this branch.
- install dependencies
- test that the issues described above have been fixed

#### What are the relevant pivotal tracker stories?
#166491349

#### Screenshot(s)
N/A
