### PR TITLE
#166503719 Fix event card shadow depth

### DIFF
--- a/client/assets/components/_event-card.scss
+++ b/client/assets/components/_event-card.scss
@@ -140,7 +140,7 @@
   }
   
   &:hover {
-    box-shadow: 0 rem(4px) rem(10px) rgba(0, 0, 0, 0.679);
+    box-shadow: 0 rem(4px) rem(10px) rgba(0, 0, 0, 0.1);
     transform: translateY(rem(-5px));
   }
 


### PR DESCRIPTION
#### What Does This PR Do?
       This PR reduces the event card shadow on hover to make it more aesthetically pleasing

#### Description Of Task To Be Completed
      - reduce event card shadow depth on hover

#### Any Background Context You Want To Provide?
     None

#### How can this be manually tested?
    Checkout to bg-fix-event-card-shadow-depth-166503719 and hover on any card to test this out

#### What are the relevant pivotal tracker stories?
[#166503719](https://www.pivotaltracker.com/story/show/166503719)

#### Screenshot(s)
None
