### PR TITLE
#166153660 Disable consent screen from popping up every time the token is refreshed

### DIFF
--- a/server/api/utils/oauth_helper.py
+++ b/server/api/utils/oauth_helper.py
@@ -27,10 +27,10 @@ def get_auth_url(andela_user):
             :param andela_user:
     """
     user_email = andela_user.user.email
-    auth_url, state = FLOW.authorization_url(prompt='consent',
-                                             included_granted_scopes='true',
-                                             login_hint=user_email,
-                                             access_type='offline')
+    auth_url, state = \
+        FLOW.authorization_url(prompt='consent', included_granted_scopes='true', login_hint=user_email,
+            access_type='offline') if andela_user.credential is None \
+                else FLOW.authorization_url(included_granted_scopes='true', login_hint=user_email, access_type='offline')
 
     andela_user.state = state
     andela_user.save()


### PR DESCRIPTION
#### What Does This PR Do?
- This PR prevents consent screen from popping out every time the access token of the user expires but rather refreshes it in the background

#### Description Of Task To Be Completed
- When a request is made, a check is made to see the value of the user's profile credential column. If the value is `NULL`, then a consent screen is presented to the user else the token is refreshed in the background without any consent screen presented to the user

#### Any Background Context You Want To Provide?
- N/A

#### How can this be manually tested?
- pull the branch to your local machine by running `git fetch origin ft-disable-calendar-prompt-166153660`
- checkout to the branch by running `git checkout ft-disable-calendar-prompt-166153660`
- ensure that the front-end and back-end servers are running
- try creating an event and if that is your first time, the consent screen will pop up and after you authenticate Andela Socials, the event will be created
- wait for a period of one hour since that is the duration of the token expiry and try creating another event. Your token will be refreshed and the event will be created without any consent screen presented to you.
- The consent screen is presented to the user once and that is when the user first uses the application. After that, the consent screen no longer shows up.

#### What are the relevant pivotal tracker stories?
[#166153660](https://www.pivotaltracker.com/story/show/166153660)
