### PR TITLE
#166502105 Display loader while events are still loading

### DIFF
--- a/client/assets/pages/_events-page.scss
+++ b/client/assets/pages/_events-page.scss
@@ -113,6 +113,14 @@
       transition: all .4s;
     }
   }
+
+  &__loading {
+    display: grid;
+    grid-column: event-gallery-start/event-gallery-end;
+    grid-template-rows: 30rem;
+    align-items: center;
+    justify-content: center;
+  }
 }
 
 .calenders {

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -40,12 +40,9 @@ class EventsPage extends React.Component {
   */
   componentDidMount() {
     const { eventStartDate } = this.state;
-    this.setState({ isLoadingEvents: true });
 
+    this.setState({ isLoadingEvents: true });
     this.getEvents({ startDate: eventStartDate });
-    this.getCategories({
-      first: 20, last: 20,
-    });
   }
 
   /**
@@ -56,21 +53,25 @@ class EventsPage extends React.Component {
    * @static
    */
   static getDerivedStateFromProps(props) {
-    const {
-      events: {
-        eventList, pageInfo: { hasNextPage },
-      }, socialClubs,
-    } = props;
-    const eventLength = eventList.length;
-    const lastEventItemCursor = eventLength ? eventList[eventLength - 1].cursor : '';
+    const { events } = props;
+    if (events && events.eventList) {
+      const {
+        events: {
+          eventList, pageInfo: { hasNextPage },
+        }, socialClubs,
+      } = props;
+      const eventLength = eventList.length;
+      const lastEventItemCursor = eventLength ? eventList[eventLength - 1].cursor : '';
 
-    return {
-      eventList,
-      hasNextPage,
-      categoryList: socialClubs.socialClubs,
-      lastEventItemCursor,
-      isLoadingEvents: false,
-    };
+      return {
+        eventList,
+        hasNextPage,
+        categoryList: socialClubs.socialClubs,
+        lastEventItemCursor,
+        isLoadingEvents: false,
+      };
+    }
+    return null;
   }
 
   getFilteredEvents(filterDate, filterLocation, filterCategory) {

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -9,12 +9,12 @@ import formatDate from '../../utils/formatDate';
 import { getEventsList, createEvent } from '../../actions/graphql/eventGQLActions';
 import { getCategoryList } from '../../actions/graphql/categoryGQLActions';
 import NoEvents from '../../components/NoEvents';
+import Spinner from '../../utils/Spinner';
 import mapListToComponent from '../../utils/mapListToComponent';
 import { ModalContextCreator } from '../../components/Modals/ModalContext';
 
 /**
  * @description  contains events dashboard page
- *
  * @class EventsPage
  * @extends {React.Component}
  */
@@ -28,38 +28,49 @@ class EventsPage extends React.Component {
       selectedCategory: '',
       eventStartDate: formatDate(Date.now(), 'YYYY-MM-DD'),
       lastEventItemCursor: '',
+      isLoadingEvents: false,
     };
     this.getFilteredEvents = this.getFilteredEvents.bind(this);
   }
 
   /**
- * React Lifecycle hook
- *
- * @memberof EventsPage
- * @returns {null}
- */
+   * React Lifecycle hook
+   * @memberof EventsPage
+   * @returns {null}
+  */
   componentDidMount() {
     const { eventStartDate } = this.state;
+    this.setState({ isLoadingEvents: true });
+
     this.getEvents({ startDate: eventStartDate });
     this.getCategories({
       first: 20, last: 20,
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  /**
+   * React Lifecycle hook
+   * @memberof EventsPage
+   * @param {Object} props
+   * @returns state
+   * @static
+   */
+  static getDerivedStateFromProps(props) {
     const {
       events: {
         eventList, pageInfo: { hasNextPage },
       }, socialClubs,
-    } = nextProps;
+    } = props;
     const eventLength = eventList.length;
     const lastEventItemCursor = eventLength ? eventList[eventLength - 1].cursor : '';
-    this.setState({
+
+    return {
       eventList,
       hasNextPage,
       categoryList: socialClubs.socialClubs,
       lastEventItemCursor,
-    });
+      isLoadingEvents: false,
+    };
   }
 
   getFilteredEvents(filterDate, filterLocation, filterCategory) {
@@ -84,10 +95,8 @@ class EventsPage extends React.Component {
   }
 
   /**
-  * @description Gets list of events
-   *
+   * @description Gets list of events
    * @memberof EventsPage
-   *
    * @param {string} startDate
    * @param {string} venue
    * @param {string} category
@@ -105,10 +114,9 @@ class EventsPage extends React.Component {
   }
 
   /**
-  * @description Gets list of categories
-   *
+   * @description Gets list of categories
    * @memberof EventsPage
-   */
+  */
   getCategories = ({
     first,
     last,
@@ -121,10 +129,9 @@ class EventsPage extends React.Component {
   }
 
   /**
-  * @description It loads more list of events
-  *
+   * @description It loads more list of events
    * @memberof EventsPage
-   */
+  */
   loadMoreEvents = () => {
     const {
       eventStartDate,
@@ -141,12 +148,22 @@ class EventsPage extends React.Component {
   }
 
   /**
-  * @description It renders list of event card
-  *
+   * @description It renders list of event card
    * @memberof EventsPage
    */
   renderEventGallery = () => {
-    const { eventList } = this.state;
+    const {
+      eventList, isLoadingEvents,
+    } = this.state;
+
+    if (isLoadingEvents) {
+      return (
+        <div className="event__loading">
+          <Spinner spinnerHeight={20} spinnerWidth={20} />
+        </div>
+      );
+    }
+
     if (eventList.length) {
       const listOfEventCard = mapListToComponent(eventList, EventCard);
       return (<div className="event__gallery">
@@ -158,8 +175,7 @@ class EventsPage extends React.Component {
   }
 
   /**
-  * @description It renders the create event FAB button
-  *
+   * @description It renders the create event FAB button
    * @memberof EventsPage
    */
   renderCreateEventButton = () => (

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -1,7 +1,7 @@
 export default {
   activeUser: {},
   event: {},
-  events: [],
+  events: {},
   subscribedEvents: [],
   redirectUrl: '',
   interest: {},
@@ -14,8 +14,6 @@ export default {
   eventsSearchList: [],
   oauth: '',
   invite: {},
-  slackChannels: [],
-  ui: {
-    subNavHidden: false,
-  },
+  slackChannels: {},
+  ui: { subNavHidden: false },
 };

--- a/client/store/configureStore.js
+++ b/client/store/configureStore.js
@@ -7,7 +7,9 @@ import rootReducer from '../reducers/index';
 import saveTokenMiddleware from '../middleware/auth';
 
 // blacklist ui state so they're not persisted
-const config = { key: 'root', storage, blacklist: ['uiReducers'] };
+const config = {
+  key: 'root', storage, blacklist: ['uiReducers', 'events'],
+};
 const reducers = persistCombineReducers(config, rootReducer);
 const middleware = [thunk, saveTokenMiddleware];
 
@@ -22,12 +24,16 @@ const configureStore = (initialState) => {
     reducers,
     compose(
       applyMiddleware(...middleware),
+      // eslint-disable-next-line no-underscore-dangle
       window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f,
     )
   );
   const persistor = persistStore(store);
+  window.persistor = persistor;
 
-  return { persistor, store };
+  return {
+    persistor, store,
+  };
 };
 
 export default configureStore;

--- a/client/store/configureStore.js
+++ b/client/store/configureStore.js
@@ -29,7 +29,6 @@ const configureStore = (initialState) => {
     )
   );
   const persistor = persistStore(store);
-  window.persistor = persistor;
 
   return {
     persistor, store,

--- a/client/utils/Spinner.js
+++ b/client/utils/Spinner.js
@@ -1,28 +1,38 @@
-import React, { Component } from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
- * @description Displays a spinner. Note: you can pass spinner height 
+ * @description Displays a spinner. Note: you can pass spinner height
  * and width as props.
- * 
  * @function Spinner
- * 
  * @param {object} props
- * 
  * @returns {views} Spinner
  */
 const Spinner = (props) => {
-  const { spinnerHeight, spinnerWidth } = props;
+  const {
+    spinnerHeight, spinnerWidth,
+  } = props;
+  const height = spinnerHeight === 0 ? '100vh' : spinnerHeight;
+  const width = spinnerWidth === 0 ? '100%' : spinnerWidth;
   return (
     <div className="spinner_container"
       style={{
-        height: spinnerHeight || "100vh",
-        width: spinnerWidth || "100%"
+        height,
+        width,
       }} >
-      <div className="spinner">
-        &nbsp;
-      </div>
+      <div className="spinner"/>
     </div >
-  )
-}
+  );
+};
+
+Spinner.propTypes = {
+  spinnerHeight: PropTypes.number,
+  spinnerWidth: PropTypes.number,
+};
+
+Spinner.defaultProps = {
+  spinnerHeight: 0,
+  spinnerWidth: 0,
+};
 
 export default Spinner;


### PR DESCRIPTION
#### What Does This PR Do?
This PR displays a spinner while event is being fetched on `Events page`

#### Description Of Task To Be Completed
- update Spinner component
- update events page css styles
- render spinner when events are being fetched
- fix issue with redux-persist
- set initial events state to empty object
- fix eslint errors

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
- pull branch
- start app and navigate to `/events`
- A spinner should be displayed before events are rendered.

#### What are the relevant pivotal tracker stories?
[#166502105](https://www.pivotaltracker.com/story/show/166502105)

#### Screenshot(s)
![events-loader](https://user-images.githubusercontent.com/28438068/59287545-c1a85500-8c69-11e9-8765-b49838a389b8.gif)
