### PR TITLE
#166284305 Replace or remove all dashboard routes

### DIFF
--- a/client/components/External.js
+++ b/client/components/External.js
@@ -13,7 +13,7 @@ const External = (props) => {
     savePermission(location.search);
   }
   if (oauth !== '') {
-    return (<Redirect to="/dashboard" />);
+    return (<Redirect to="/events" />);
   }
   return (
     <Spinner />

--- a/client/components/common/SubNav.js
+++ b/client/components/common/SubNav.js
@@ -44,7 +44,7 @@ class SubNav extends Component {
     return (
       <div className={`navbar ${subNavHidden ? 'navbar-hide' : ''}`}>
         <div className="navbar__bottom-section">
-          <NavMenu to="/dashboard">Dashboard</NavMenu>
+          <NavMenu to="/events">Events</NavMenu>
         </div>
       </div>
     );

--- a/client/pages/Dashboard/index.jsx
+++ b/client/pages/Dashboard/index.jsx
@@ -191,7 +191,6 @@ class Dashboard extends Component {
             />
             <Route path="/invite/:inviteHash" component={Invite} />
             <Route path="/events" render={() => <EventsPage createEvent={createEvent} categories={categories} uploadImage={uploadImage} />} />
-            <Route path="/dashboard" render={() => <EventsPage createEvent={createEvent} categories={categories} uploadImage={uploadImage} />} />
             <Route path="/interests" render={() => <Interests />} />
             <Route path="*" component={NotFound} />
           </Switch>

--- a/client/pages/Event/EventDetailsPage.jsx
+++ b/client/pages/Event/EventDetailsPage.jsx
@@ -226,7 +226,7 @@ class EventDetailsPage extends React.Component {
   // eslint-disable-next-line react/sort-comp
   handleBack() {
     const { history: { push } } = this.props;
-    push('/dashboard');
+    push('/events');
   }
 
   loadEvent() {

--- a/client/pages/Interests/index.jsx
+++ b/client/pages/Interests/index.jsx
@@ -106,7 +106,7 @@ class Interests extends React.Component {
 
   redirectToHomePage = (closeModal) => {
     closeModal();
-    this.props.history.push('/dashboard');
+    this.props.history.push('/events');
   }
 
   showAuthenticateModal = () => (


### PR DESCRIPTION
#### What Does This PR Do?
This PR removes unnecessary dashboard routes and renames dashboard routes to events.
#### Description Of Task To Be Completed
- Remove unnecessary dashboard routes
- Rename '/dashboard' routes to '/events'
#### Any Background Context You Want To Provide?
Since there is no dashboard within the application, It would be confusing to have routes that bears the name `dashboard`. Presently, the `/dashboard` routes points to the `events` listing page, hence the need to replace all '/dashboard' to '/events'/.
This will ensure that users aint confused when navigating the app.
#### How can this be manually tested?
Pull this branch and visit the events page.
#### What are the relevant github issues?
n/a
#### Screenshot(s)
<img width="1097" alt="Screen Shot 2019-06-10 at 2 30 23 AM" src="https://user-images.githubusercontent.com/27797745/59167174-d54ba280-8b27-11e9-9054-ab637fee3f1c.png">
