### PR TITLE
#166604318 Fix current category not pre-populated with current category before update

### DIFF
--- a/client/components/common/CustomDropDown.js
+++ b/client/components/common/CustomDropDown.js
@@ -19,6 +19,14 @@ class CustomDropDown extends Component {
     this.selectedItem = this.selectedItem.bind(this);
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.title !== this.props.title) {
+      this.setState({
+        headerTitle: this.props.title
+      })
+    }
+  }
+
   handleClickOutside() {
     this.setState({ listOpen: false });
   }
@@ -45,28 +53,28 @@ class CustomDropDown extends Component {
 
     return (
       <div className="cd-wrapper">
-      <div className="cd-header" onClick={() => this.toggleList()}>
-        <div className="cd-title">
-          <span className="cd-header-title">{headerTitle}</span>
-        </div>
-        <div className="cd-icon">
-        {listOpen
-          ? <FontAwesome name="angle-up" size="2x"/>
-          : <FontAwesome name="angle-down" size="2x"/>
-        }
-        </div>
+        <div className="cd-header" onClick={() => this.toggleList()}>
+          <div className="cd-title">
+            <span className="cd-header-title">{headerTitle}</span>
+          </div>
+          <div className="cd-icon">
+            {listOpen
+              ? <FontAwesome name="angle-up" size="2x" />
+              : <FontAwesome name="angle-down" size="2x" />
+            }
+          </div>
 
-      </div>
-       {listOpen && <ul className="cd-list">
-         {list.map(item => (
-           <li
-            className="cd-list__item"
-            onClick={(event) => this.selectedItem(event, item)}
-            key={item.id}
+        </div>
+        {listOpen && <ul className="cd-list">
+          {list.map(item => (
+            <li
+              className="cd-list__item"
+              onClick={(event) => this.selectedItem(event, item)}
+              key={item.id}
             >
               {item.title}
             </li>
-         ))}
+          ))}
         </ul>}
       </div>
     );


### PR DESCRIPTION

#### What Does This PR Do?
This PR pre-populate the update event form with the current event category

#### Description Of Task To Be Completed
- add react life cycle to update the state with props

#### Any Background Context You Want To Provide?

#### How can this be manually tested?
- `git pull mvp-develop`
- `git checkout bg-fix-pre-populate-category-166604318` and `make start`
- click on any event created by you and click on the update button,
 you will see the category field pre-populated

#### What are the relevant pivotal tracker stories?
[#166604318](https://www.pivotaltracker.com/story/show/166604318)

#### Screenshot(s)
Nil