### PR TITLE
#166604625 Persist selected startDate in events page

### DIFF
--- a/client/actions/constants.js
+++ b/client/actions/constants.js
@@ -30,6 +30,7 @@ export const SET_REDIRECT_URL = 'SET_REDIRECT_URL';
 export const LOAD_ACTIVE_USER_SUCCESS = 'LOAD_ACTIVE_USER_SUCCESS';
 export const ATTEND_EVENT = 'ATTEND_EVENT';
 export const UNATTEND_EVENT = 'UNATTEND_EVENT';
+export const CHANGE_START_DATE = 'CHANGE_START_DATE';
 
 // Constants specific to attendees
 export const GET_ATTENDEES = 'GET_ATTENDEES';

--- a/client/actions/eventActions.js
+++ b/client/actions/eventActions.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { GET_EVENT, ATTEND_EVENT, CREATE_EVENT, SUBSCRIBED_EVENTS, UNATTEND_EVENT } from './constants';
+import { GET_EVENT, ATTEND_EVENT, CREATE_EVENT, SUBSCRIBED_EVENTS, UNATTEND_EVENT, CHANGE_START_DATE } from './constants';
 import { handleError } from '../utils/errorHandler';
 
 import { LinkError } from 'apollo-link/lib/linkUtils';
@@ -74,4 +74,8 @@ export const unsubscribeEvent = (event) => {
       })
       .catch(error => handleError(error, dispatch));
   };
+}
+
+export const changeStartDate = (startDate) => {
+  return (dispatch) => dispatch({ type: CHANGE_START_DATE, payload: startDate });
 }

--- a/client/components/common/Calendar.js
+++ b/client/components/common/Calendar.js
@@ -4,12 +4,10 @@ import dateFns from 'date-fns';
 class Calendar extends React.Component {
   state = {
     currentMonth: new Date(),
-    selectedDate: new Date(),
   };
 
   onDateClick = (day) => {
-    this.setState({ selectedDate: day });
-    this.props.dateSelected(dateFns.format(day, 'YYYY-MM-DD'));
+    this.props.dateSelected({ startDate: dateFns.format(day, 'YYYY-MM-DD') });
   };
 
   nextMonth = () => {
@@ -37,7 +35,8 @@ class Calendar extends React.Component {
   }
 
   renderCells() {
-    const { currentMonth, selectedDate } = this.state;
+    const { currentMonth } = this.state; 
+    const { selectedDate } = this.props; 
     const monthStart = dateFns.startOfMonth(currentMonth);
     const monthEnd = dateFns.endOfMonth(monthStart);
     const startDate = dateFns.startOfWeek(monthStart);

--- a/client/components/filter/EventFilter.js
+++ b/client/components/filter/EventFilter.js
@@ -36,7 +36,7 @@ class EventFilter extends React.Component {
       category,
     } = this.state;
     if (filterSelected !== undefined) {
-      filterSelected(null, location, category);
+      filterSelected({ location, category });
     }
   }
 

--- a/client/reducers/eventReducers.js
+++ b/client/reducers/eventReducers.js
@@ -14,6 +14,7 @@ import {
   SIGN_OUT,
   UPLOAD_IMAGE,
   SHARE_EVENT,
+  CHANGE_START_DATE,
 } from '../actions/constants';
 import initialState from './initialState';
 
@@ -27,12 +28,12 @@ export const events = (state = initialState.events, action) => {
   switch (action.type) {
     case GET_EVENTS:
       const { edges, pageInfo } = action.payload;
-      return { eventList: edges, pageInfo };
+      return { ...state, eventList: edges, pageInfo };
 
     case LOAD_MORE_EVENTS:
       const { eventList } = state;
       const { edges: newEvents, pageInfo: newPageInfo } = action.payload;
-      return { eventList: [...eventList, ...newEvents], pageInfo: newPageInfo };
+      return { ...state, eventList: [...eventList, ...newEvents], pageInfo: newPageInfo };
 
     case CREATE_EVENT: {
       const newEvent = { node: action.payload.createEvent.newEvent };
@@ -51,6 +52,9 @@ export const events = (state = initialState.events, action) => {
       });
       return { ...state, eventList: [...updated], status: 'updated' };
     }
+
+    case CHANGE_START_DATE: 
+      return { ...state, startDate: action.payload }
 
     case DEACTIVATE_EVENT: {
       const newEventList = state.eventList.filter(item => item.node.id !== action.payload.id);


### PR DESCRIPTION
#### What Does This PR Do?
Persist selected startDate in events page

#### Description Of Task To Be Completed
- add startDate to redux store
- refactor getFilteredEvents
- fetch events when filter or startDate changes

#### Any Background Context You Want To Provide?
Currently, when user filters events by date and clicks and event to view it, the selected date is lost when back button is clicked. This PR ensures selected date is persisted

#### How can this be manually tested?
- Clone the repo
- Switch to this branch
- Install dependencies and run `make start` to start the app.
- Navigate to events list page
- Filter event by date
- Click an event to view details
- Click back button, notice that the selected date is still persisted.

#### What are the relevant pivotal tracker stories?
#166604625

#### Screenshot(s)
![Demo](https://user-images.githubusercontent.com/26779819/59612480-0eca7200-9115-11e9-94af-b75660fb55fa.gif)