### PR TITLE
#166603719 Add all as option on filter dropdown

### DIFF
--- a/client/components/filter/EventFilter.js
+++ b/client/components/filter/EventFilter.js
@@ -9,7 +9,13 @@ class EventFilter extends React.Component {
     this.state = {
       location: '',
       category: '',
-      list: [ // todo: remove, just for test
+      locationList: [ // todo: remove, just for test
+        {
+          id: null,
+          title: 'All',
+          selected: false,
+          key: 'location',
+        },
         {
           id: 'Lagos',
           title: 'Lagos',
@@ -36,7 +42,7 @@ class EventFilter extends React.Component {
       category,
     } = this.state;
     if (filterSelected !== undefined) {
-      filterSelected({ location, category });
+      filterSelected({ filterLocation: location, filterCategory: category });
     }
   }
 
@@ -49,15 +55,24 @@ class EventFilter extends React.Component {
   }
 
   render() {
+    const updatedCategoryList = [
+        {
+          id: null,
+          title: 'All',
+          selected: false,
+          key: 'category',
+        },
+        ...this.props.categoryList
+      ]
     return (
       <div className="filter__container" >
-        <div className="filter__title">Filter Events </div>
+        <div className="filter__title">Filter Events</div>
         <div className="filter__box">
           <div>
             Location
             <CustomDropDown
               title="Select location"
-              list={this.state.list}
+              list={this.state.locationList}
               onSelected={this.onLocationChange}
             />
           </div>
@@ -65,7 +80,7 @@ class EventFilter extends React.Component {
             Category
             <CustomDropDown
               title="Select category"
-              list={this.props.categoryList}
+              list={updatedCategoryList}
               onSelected={this.onCategoryChange}
             />
           </div>

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -76,13 +76,20 @@ class EventsPage extends React.Component {
     return null;
   }
 
-  getFilteredEvents({ startDate, location, category }) {
+  getFilteredEvents({ startDate, filterLocation, filterCategory }) {
+    const {
+      selectedVenue,
+      selectedCategory,
+    } = this.state;
+    const location = filterLocation === null ? null : (filterLocation || selectedVenue);
+    const category = filterCategory === null ? null : (filterCategory || selectedCategory);
+
     startDate && this.props.changeStartDate(startDate);
     this.setState(
       () => {
         const filter = {};
-        location && (filter.selectedVenue = location);
-        category && (filter.selectedCategory = category);
+        filter.selectedVenue = location;
+        filter.selectedCategory = category;
         return Object.keys(filter).length ? filter : null;
       }
     );


### PR DESCRIPTION
#### What Does This PR Do?
   This PR adds an all option to the filter dropdown so that it can be easy to clear the filter and reset the filter to showing all the events

#### Description Of Task To Be Completed
     - include all as filter option on the location dropdown
     - include all as filter option on the categories dropdown

#### Any Background Context You Want To Provide?
     N/A

#### How can this be manually tested?
     checkout to  bg-add-all-to-filter-166603719 and the click on any of the filter dropdown and the you should see an option to display all

#### What are the relevant pivotal tracker stories?
[#166603719](https://www.pivotaltracker.com/story/show/166603719)

#### Screenshot(s)
N/A
