### PR TITLE
Fix load more event filter bug

### DIFF
--- a/client/assets/components/_dropdown.scss
+++ b/client/assets/components/_dropdown.scss
@@ -9,7 +9,10 @@
     background-color: #FFFFFF;
     font-size: 1.25rem;
     max-height: rem(120px);
-  
+    overflow-y: scroll;
+    li {
+      padding: 5px 10px;
+    }
     &__list:hover {
       background-color: #EEEEEE;
     }

--- a/client/components/Forms/EventForm.js
+++ b/client/components/Forms/EventForm.js
@@ -335,7 +335,6 @@ class EventForm extends Component {
   };
 
   render() {
-    console.log(this.props, 'state>>>>>')
     const { errors, categoryIsValid, timezoneIsValid, timezone } = this.state;
     const { formId, formData, categories, slackChannels } = this.props;
     const listChannels = slackChannels && slackChannels.map(channel => this.renameKey('name', 'title', channel));

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -100,7 +100,7 @@ class EventsPage extends React.Component {
       prevState.selectedCategory !== selectedCategory
     ) {
       this.getEvents({
-        startDate,
+        startDate: startDate || formatDate(Date.now(), 'YYYY-MM-DD'),
         venue: selectedVenue,
         category: selectedCategory,
       });
@@ -154,7 +154,7 @@ class EventsPage extends React.Component {
     const { startDate } = this.props.events;
 
     this.getEvents({
-      startDate,
+      startDate: startDate || formatDate(Date.now(), 'YYYY-MM-DD'),
       venue: selectedVenue,
       category: selectedCategory,
       after: lastEventItemCursor,


### PR DESCRIPTION
#### What Does This PR Do?

#### Description Of Task To Be Completed
- [x] fix load more showing events on with a different date from the startdate when startdate is undefined
- [x] fix typo error by changing user_profile.slack_tokena to user_profile.slack_token
- [x] remove unnecessary console.log in EventForm
- [x] add y axis scroll to eventdetail slack channel list dropdown

#### Any Background Context You Want To Provide?
- None
#### How can this be manually tested?
- start the app
- click load more and events shown should only be that of the current date on first load
#### What are the relevant pivotal tracker stories?
[#166791002](https://www.pivotaltracker.com/story/show/166791002)
#### Screenshot(s)
