### PR TITLE
#166491378 Make toast error messages user friendly

### DIFF
--- a/server/graphql_schemas/event/schema.py
+++ b/server/graphql_schemas/event/schema.py
@@ -114,7 +114,8 @@ class CreateEvent(relay.ClientIDMutation):
                 raise_calendar_error(user_profile)
 
         except ValueError as e:
-            raise GraphQLError("An Error occurred. \n{}".format(e))
+            logging.warn(e)
+            raise GraphQLError("An Error occurred. Please try again")
 
         slack_token = False
         if user_profile.slack_tokena:
@@ -239,9 +240,10 @@ class UpdateEvent(relay.ClientIDMutation):
                     action_message="Event Update is successful.",
                     updated_event=updated_event
                 )
-        except ValueError as e:
+        except Exception as e:
             # return an error if something wrong happens
-            raise GraphQLError("An Error occurred. \n{}".format(e))
+            logging.warn(e)
+            raise GraphQLError("An Error occurred. Please try again")
 
 
 class DeactivateEvent(relay.ClientIDMutation):
@@ -428,6 +430,7 @@ class ShareEvent(relay.ClientIDMutation):
                 blocks, "New upcoming event from Andela socials", channel_id)
 
         except ValueError as e:
+            logging.warn(e)
             raise GraphQLError("An Error occurred. Please try again")
 
         return ShareEvent(event=event)


### PR DESCRIPTION
#### What Does This PR Do?
This PR ensures that some of the GraphQL errors returned are user-friendly

#### Description Of Task To Be Completed
  - Change error format returned from GraphQL
  - Add exception logging

#### Any Background Context You Want To Provide?
anytime an exception is thrown, the error messages that are displayed to the user, aren't usually understandable by the end users

#### How can this be manually tested?
  - Checkout to branch `bg-user-friendly-toast-errors-166491378`
  - Modify a variable name in the method for updating an event on the server side in the `events` 
     GraphQL schema
  - Startup both client and server side
  - Try to update the information of an event

#### What are the relevant pivotal tracker stories?
[#166491378](https://www.pivotaltracker.com/story/show/166491378)

#### Screenshot(s)
N/A
