### PR TITLE
#166752486 remove events from blacklist

### DIFF
--- a/client/actions/constants.js
+++ b/client/actions/constants.js
@@ -10,6 +10,7 @@ export const JOINED_CLUBS = 'JOINED_CLUBS';
 // Constants specific to events
 export const GET_EVENT = 'GET_EVENT';
 export const GET_EVENTS = 'GET_EVENTS';
+export const GET_EVENTS_LOADING = 'GET_EVENTS_LOADING';
 export const LOAD_MORE_EVENTS = 'LOAD_MORE_EVENTS';
 export const SEARCH_EVENTS = 'SEARCH_EVENTS';
 

--- a/client/actions/graphql/eventGQLActions.js
+++ b/client/actions/graphql/eventGQLActions.js
@@ -9,6 +9,7 @@ import {
   GET_EVENT,
   CREATE_EVENT,
   GET_EVENTS,
+  GET_EVENTS_LOADING,
   UPDATE_EVENT,
   LOAD_MORE_EVENTS,
   DEACTIVATE_EVENT,
@@ -27,13 +28,27 @@ export const getEventsList = ({
   startDate,
   venue,
   category,
-}) => dispatch => Client.query(EVENT_LIST_GQL(after, first, title, startDate, venue, category))
-  .then(data => dispatch({
-    type: after ? LOAD_MORE_EVENTS : GET_EVENTS,
-    payload: data.data.eventsList,
-    error: false,
-  }))
-  .catch(error => handleError(error, dispatch));
+}) => (dispatch) => {
+  dispatch({
+    type: GET_EVENTS_LOADING,
+    payload: true,
+  });
+  Client.query(EVENT_LIST_GQL(after, first, title, startDate, venue, category))
+  .then((data) => {
+    const { eventsList } = data.data;
+    eventsList.requestedStartDate = startDate;
+    dispatch({
+      type: after ? LOAD_MORE_EVENTS : GET_EVENTS,
+      payload: eventsList,
+      error: false,
+    })
+  })
+  .catch(error => handleError(error, dispatch))
+  .finally(dispatch({
+    type: GET_EVENTS_LOADING,
+    payload: false,
+  }));
+};
 
 /**
  * This commented out code below has a use case

--- a/client/pages/Event/EventsPage.jsx
+++ b/client/pages/Event/EventsPage.jsx
@@ -58,7 +58,10 @@ class EventsPage extends React.Component {
     if (events && events.eventList) {
       const {
         events: {
-          eventList, pageInfo: { hasNextPage },
+          eventList,
+          pageInfo: { hasNextPage },
+          getEventsLoading,
+          requestedStartDate,
         }, socialClubs, slackToken,
       } = props;
       const eventLength = eventList.length;
@@ -69,7 +72,8 @@ class EventsPage extends React.Component {
         hasNextPage,
         categoryList: socialClubs.socialClubs,
         lastEventItemCursor,
-        isLoadingEvents: false,
+        isLoadingEvents: getEventsLoading,
+        requestedStartDate,
         slackToken,
       };
     }
@@ -174,8 +178,16 @@ class EventsPage extends React.Component {
    */
   renderEventGallery = () => {
     const {
-      eventList, isLoadingEvents,
+      eventList, isLoadingEvents, requestedStartDate,
     } = this.state;
+    const { startDate } = this.props.events;
+
+    if (eventList.length && startDate === requestedStartDate) {
+      const listOfEventCard = mapListToComponent(eventList, EventCard);
+      return (<div className="event__gallery">
+        {listOfEventCard}
+      </div>);
+    }
 
     if (isLoadingEvents) {
       return (
@@ -183,13 +195,6 @@ class EventsPage extends React.Component {
           <Spinner spinnerHeight={20} spinnerWidth={20} />
         </div>
       );
-    }
-
-    if (eventList.length) {
-      const listOfEventCard = mapListToComponent(eventList, EventCard);
-      return (<div className="event__gallery">
-        {listOfEventCard}
-      </div>);
     }
 
     return <NoEvents />;
@@ -255,6 +260,7 @@ class EventsPage extends React.Component {
     const {
       categoryList,
       hasNextPage,
+      requestedStartDate,
     } = this.state;
     const { subNavHidden, events: { startDate } } = this.props;
     const catList = Array.isArray(categoryList) ? categoryList.map(item => ({
@@ -273,7 +279,7 @@ class EventsPage extends React.Component {
         </div>
         {this.renderEventGallery()}
         {this.openSlackModal()}
-        <div className={`event__footer ${hasNextPage ? '' : 'event__footer--hidden'}`} >
+        <div className={`event__footer ${hasNextPage && startDate === requestedStartDate ? '' : 'event__footer--hidden'}`} >
           <button onClick={this.loadMoreEvents} type="button" className="btn-blue event__load-more-button">
             Load more
           </button>

--- a/client/reducers/eventReducers.js
+++ b/client/reducers/eventReducers.js
@@ -15,6 +15,7 @@ import {
   UPLOAD_IMAGE,
   SHARE_EVENT,
   CHANGE_START_DATE,
+  GET_EVENTS_LOADING,
 } from '../actions/constants';
 import initialState from './initialState';
 
@@ -27,8 +28,11 @@ import initialState from './initialState';
 export const events = (state = initialState.events, action) => {
   switch (action.type) {
     case GET_EVENTS:
-      const { edges, pageInfo } = action.payload;
-      return { ...state, eventList: edges, pageInfo };
+      const { edges, pageInfo, requestedStartDate } = action.payload;
+      return { ...state, eventList: edges, pageInfo, requestedStartDate, };
+
+    case GET_EVENTS_LOADING:
+      return { ...state, getEventsLoading: action.payload };
 
     case LOAD_MORE_EVENTS:
       const { eventList } = state;

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -1,7 +1,9 @@
 export default {
   activeUser: {},
   event: {},
-  events: {},
+  events: {
+    getEventsLoading: false,
+  },
   subscribedEvents: [],
   redirectUrl: '',
   interest: {},

--- a/client/store/configureStore.js
+++ b/client/store/configureStore.js
@@ -8,7 +8,7 @@ import saveTokenMiddleware from '../middleware/auth';
 
 // blacklist ui state so they're not persisted
 const config = {
-  key: 'root', storage, blacklist: ['uiReducers', 'events'],
+  key: 'root', storage, blacklist: ['uiReducers', ],
 };
 const reducers = persistCombineReducers(config, rootReducer);
 const middleware = [thunk, saveTokenMiddleware];


### PR DESCRIPTION
#### What Does This PR Do?
This PR removes events from blacklist while still handling loading state of events

#### Description Of Task To Be Completed
- add getEventsLoading state to store
- add requestedStartDate to store
- modify EventsPage.jsx to render events on availability before rendering load state

#### Any Background Context You Want To Provide?
Initially 'events' states were blacklisted from being persisted in localStorage

#### How can this be manually tested?
- Clone the repo
- Switch to this branch
- Install dependencies and run `make start` to start the app.
- Navigate to events list page
- Select a date
- Refresh the browser window and notice events state being persisted

#### What are the relevant pivotal tracker stories?
#166752486

#### Screenshot(s)
N/A