### PR TITLE
#166284735: Filter events user is attending

### DIFF
--- a/server/graphql_schemas/attend/schema.py
+++ b/server/graphql_schemas/attend/schema.py
@@ -54,6 +54,7 @@ class AttendQuery(object):
     event_attendance = relay.Node.Field(AttendNode)
     attenders_list = DjangoFilterConnectionField(AttendNode)
     subscribed_events = graphene.List(AttendNode)
+    attending_list = DjangoFilterConnectionField(AttendNode)
 
     def resolve_subscribed_events(self, info, **kwargs):
         user = info.context.user
@@ -65,6 +66,10 @@ class AttendQuery(object):
             Q(user__user=info.context.user) |
             Q(event__creator__user=info.context.user)
         )
+
+    def resolve_attending_list(self, info, **kwargs):
+        return Attend.objects.filter(user__user=info.context.user,
+                                     status="attending")
 
 
 class AttendMutation(ObjectType):

--- a/server/graphql_schemas/tests/attend/test_queries.py
+++ b/server/graphql_schemas/tests/attend/test_queries.py
@@ -119,3 +119,26 @@ class AttendanceTestCase(BaseEventTestCase):
         self.request.user = self.andela_user.user
         result = self.client.execute(query, context_value=self.request)
         self.assertMatchSnapshot(result)
+
+    def test_can_fetch_events_user_is_attending(self):
+        query = '''
+            query{
+                attendingList{
+                    edges{
+                        node{
+                            id
+                            user{
+                                id
+                            }
+                            event{
+                                id
+                                title
+                            }
+                        }
+                    }
+                }
+            }
+        '''
+        self.request.user = self.andela_user.user
+        result = self.client.execute(query, context_value=self.request)
+        self.assertMatchSnapshot(result)


### PR DESCRIPTION

#### What Does This PR Do?
- Adds functionality that enables a user to filter by events they are attending
#### Description Of Task To Be Completed
- Create a query to fetch all events that the currently logged in user is attending
- Write tests for this functionality
#### Any Background Context You Want To Provide?
N/A
#### How can this be manually tested?
- Check out the branch 
- Seed dummy data into the database following [this](https://github.com/AndelaOSP/Andela-Socials#database-seeding) guide
- Populate the `Attend` model with relevant data
- Make the query in the screenshot attached below to get events the currently logged in user is attending!
#### What are the relevant pivotal tracker stories?
[#166284735](https://www.pivotaltracker.com/story/show/166284735)
#### Screenshot(s)
![image](https://user-images.githubusercontent.com/39732510/60034595-aef33e80-96b3-11e9-932e-a78c11d4522d.png)
