### PR TITLE
#166497823 Delete calendar event

### DIFF
--- a/server/graphql_schemas/tests/utils/test_helpers.py
+++ b/server/graphql_schemas/tests/utils/test_helpers.py
@@ -1,7 +1,6 @@
 """Module that tests helper methods"""
 from unittest.mock import patch
-from api.models import AndelaUserProfile
-from graphql_schemas.utils.helpers import update_event_status_on_calendar
+from graphql_schemas.utils.helpers import update_event_status_on_calendar, remove_event_from_all_calendars
 from api.tests.base_test_setup import BaseSetup
 
 class HelperTests(BaseSetup):
@@ -28,4 +27,20 @@ class HelperTests(BaseSetup):
         self.assertEqual(mock_build.return_value.events.return_value.patch.called, True)
         self.assertEqual(mock_build.return_value.events.return_value.get.called, True)
         self.assertEqual(mock_build.call_count, 2)
+        mock_build_patcher.stop()
+
+    def test_remove_event_from_all_calendar(self):
+        """
+        Test method that update the event status on calendar
+        Args:
+            self (Instance): HelperTests instance
+        """
+        mock_build_patcher = patch('graphql_schemas.utils.helpers.build')
+        user, event = self.andela_user1, self.event_1
+        mock_build = mock_build_patcher.start()
+        mock_build.return_value.events.return_value.delete.return_value.execute.return_value = 'event deleted'
+        remove_event_from_all_calendars(user, event)
+        self.assertEqual(mock_build.called, True)
+        self.assertEqual(mock_build.return_value.events.return_value.delete.called, True)
+        self.assertEqual(mock_build.call_count, 1)
         mock_build_patcher.stop()

--- a/server/graphql_schemas/utils/helpers.py
+++ b/server/graphql_schemas/utils/helpers.py
@@ -246,3 +246,16 @@ def update_event_status_on_calendar(andela_user, event):
             eventId=event_id,
             body=event_in_calendar
         ).execute()
+
+
+def remove_event_from_all_calendars(andela_user, event):
+    """
+    Remove an event from all calendars
+    Args:
+        andela_user(list): The user data of the person removing the event
+        event(list): The event to be removed from the calendar
+    Returns: None
+    """
+    eventId = event.event_id_in_calendar
+    calendar = build('calendar', 'v3', credentials=andela_user.credential)
+    calendar.events().delete(calendarId='primary', eventId=eventId).execute()


### PR DESCRIPTION
#### What Does This PR Do?
It deletes the event from all attendee calendar when the host deletes the event
#### Description Of Task To Be Completed
- Delete event from the calendar using the google calendar API
- Write tests for the implementation
#### Any Background Context You Want To Provide?
None
#### How can this be manually tested?
- Fetch the branch locally by running `git fetch origin ft-delete-calendar-event-166497823` & `git checkout ft-delete-calendar-event-166497823` respectively
- Create an event whose category matches with the interest of another user
- Delete the event. The event should not be in your calendar and the calendar of the attendees

#### What are the relevant pivotal tracker stories?
[166497823](https://www.pivotaltracker.com/story/show/166497823)
#### Screenshot(s)
None