### PR TITLE
#166603961 Set event slack notification as background…

### DIFF
--- a/server/api/slack.py
+++ b/server/api/slack.py
@@ -47,20 +47,25 @@ def notify_channel(message, text, channel_id=dotenv.get('DEFAULT_CHANNEL_ID')):
     )
 
 
-def notify_user(message, slack_id, **kwargs):
+def notify_user(message, slack_id, text, **kwargs):
     """
     Notify the user with the given id with the message
         :param message:
         :param slack_id - The slack id of the user:
     """
-    return slack_client.api_call(
+    slack_response = slack_client.api_call(
         "chat.postMessage",
         channel=slack_id,
         blocks=message,
         as_user=True,
         reply_broadcast=True,
+        text=text,
         **kwargs,
     )
+    if slack_response['ok']:
+        return slack_response
+    else:
+        logging.warn(slack_response)
 
 
 def get_slack_user_timezone(email):

--- a/server/api/views.py
+++ b/server/api/views.py
@@ -288,8 +288,8 @@ class SlackActionsCallback(APIView):
             except AndelaUserProfile.DoesNotExist:
                 message = generate_simple_message(
                     'Oops! It seems you no longer have an account on the platform')
-
-            notify_user(message, user_slack_id)
+            text = "Attending Event"
+            notify_user(message, user_slack_id, text)
         return Response()
 
     @staticmethod

--- a/server/graphql_schemas/utils/cron_jobs.py
+++ b/server/graphql_schemas/utils/cron_jobs.py
@@ -26,5 +26,8 @@ def check_and_notify_members():
         )
         if new_users:
             message = new_users + ' joined ' + str(category.name) + ' today.'
-            [notify_user(message, user.follower.slack_id)
-             for user in users_in_category]
+            [notify_user(
+                message,
+                user.follower.slack_id,
+                'New member joined Andela Socials'
+                ) for user in users_in_category]

--- a/server/graphql_schemas/utils/helpers.py
+++ b/server/graphql_schemas/utils/helpers.py
@@ -193,7 +193,7 @@ async def send_bulk_update_message(event_instance, message, notification_text):
                 logging.info("Rate limited. Retrying in " + str(delay) + " seconds")
                 sleep(delay)
                 notify_user(
-                    message, slack_id, text=notification_text)
+                    message, slack_id, notification_text)
             elif not slack_response['ok']:
                 logging.warning(slack_response)
 


### PR DESCRIPTION
#### What Does This PR Do?
It sets the slack notification sent to users when an event is created as a background task
#### Description Of Task To Be Completed
- Modify the notify user method
- Set then notify user method as a background task when an event is created
#### Any Background Context You Want To Provide?
None
#### How can this be manually tested?
- Fetch the branch locally by running `git fetch origin ch-slack-event-background-task-166603961` & `git checkout ch-slack-event-background-task-166603961` respectively
- Create an event
- You should get a Slack notification with the event details

#### What are the relevant pivotal tracker stories?
[166603961](https://www.pivotaltracker.com/story/show/166603961)
#### Screenshot(s)
None